### PR TITLE
Feat/default arguments

### DIFF
--- a/Analysis/src/AstJsonEncoder.cpp
+++ b/Analysis/src/AstJsonEncoder.cpp
@@ -378,7 +378,17 @@ struct AstJsonEncoder : public AstVisitor
             else
                 comma = true;
 
-            write(a);
+            if constexpr (std::is_pointer_v<T>)
+            {
+                if (a != nullptr)
+                    write(a);
+                else
+                    writeRaw("null");
+            }
+            else
+            {
+                write(a);
+            }
         }
         writeRaw("]");
     }
@@ -446,6 +456,7 @@ struct AstJsonEncoder : public AstVisitor
                 if (node->self)
                     PROP(self);
                 PROP(args);
+                PROP(argsDefaults);
                 if (node->returnAnnotation)
                     PROP(returnAnnotation);
                 PROP(vararg);

--- a/Analysis/src/AstJsonEncoder.cpp
+++ b/Analysis/src/AstJsonEncoder.cpp
@@ -9,6 +9,7 @@
 #include <math.h>
 
 LUAU_FASTFLAG(LuauTrackPrefixLocal)
+LUAU_FASTFLAG(DebugLuauDefaultArguments)
 
 namespace Luau
 {
@@ -456,7 +457,8 @@ struct AstJsonEncoder : public AstVisitor
                 if (node->self)
                     PROP(self);
                 PROP(args);
-                PROP(argsDefaults);
+                if (FFlag::DebugLuauDefaultArguments)
+                    PROP(argsDefaults);
                 if (node->returnAnnotation)
                     PROP(returnAnnotation);
                 PROP(vararg);

--- a/Analysis/src/AstJsonEncoder.cpp
+++ b/Analysis/src/AstJsonEncoder.cpp
@@ -9,7 +9,7 @@
 #include <math.h>
 
 LUAU_FASTFLAG(LuauTrackPrefixLocal)
-LUAU_FASTFLAG(DebugLuauDefaultArguments)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 namespace Luau
 {
@@ -457,7 +457,7 @@ struct AstJsonEncoder : public AstVisitor
                 if (node->self)
                     PROP(self);
                 PROP(args);
-                if (FFlag::DebugLuauDefaultArguments)
+                if (FFlag::LuauDefaultArguments)
                     PROP(argsDefaults);
                 if (node->returnAnnotation)
                     PROP(returnAnnotation);

--- a/Analysis/src/AstQuery.cpp
+++ b/Analysis/src/AstQuery.cpp
@@ -12,6 +12,8 @@
 
 #include <algorithm>
 
+LUAU_FASTFLAGVARIABLE(LuauDefaultArguments)
+
 namespace Luau
 {
 
@@ -457,10 +459,13 @@ struct FindExprOrLocal : public AstVisitor
         {
             visitLocal(fn->args.data[i]);
         }
-        for (auto arg : fn->argsDefaults)
+        if (FFlag::LuauDefaultArguments)
         {
-            if (arg)
-                visit(arg);
+            for (auto arg : fn->argsDefaults)
+            {
+                if (arg)
+                    visit(arg);
+            }
         }
         return visit((class AstExpr*)fn);
     }

--- a/Analysis/src/AstQuery.cpp
+++ b/Analysis/src/AstQuery.cpp
@@ -457,6 +457,11 @@ struct FindExprOrLocal : public AstVisitor
         {
             visitLocal(fn->args.data[i]);
         }
+        for (auto arg : fn->argsDefaults)
+        {
+            if (arg)
+                visit(arg);
+        }
         return visit((class AstExpr*)fn);
     }
 

--- a/Analysis/src/AstQuery.cpp
+++ b/Analysis/src/AstQuery.cpp
@@ -12,7 +12,7 @@
 
 #include <algorithm>
 
-LUAU_FASTFLAGVARIABLE(LuauDefaultArguments)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 namespace Luau
 {

--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -1140,11 +1140,9 @@ void ConstraintGenerator::prototypeTypeDefinitions(const ScopePtr& scope, AstSta
 
             TypeId instanceMetatable = arena->addType(TableType{instanceMetatableProps, std::nullopt, TypeLevel{}, scope.get(), TableState::Sealed});
 
-            TypeId classInstanceTy = arena->addType(
-                ExternType{
-                    declName, std::move(props), builtinTypes->objectType, instanceMetatable, Tags{}, nullptr, module->name, classDecl->location
-                }
-            );
+            TypeId classInstanceTy = arena->addType(ExternType{
+                declName, std::move(props), builtinTypes->objectType, instanceMetatable, Tags{}, nullptr, module->name, classDecl->location
+            });
 
             TypeId ctorTy =
                 arena->addType(FunctionType{arena->addTypePack({builtinTypes->unknownType, ctorArgTy}), arena->addTypePack({classInstanceTy})});
@@ -2229,8 +2227,7 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatDeclareExte
         {
             reportError(
                 declaredExternType->location,
-                GenericError{
-                    format("Cannot use non-class type '%s' as a superclass of class '%s'", superName.c_str(), declaredExternType->name.value)
+                GenericError{format("Cannot use non-class type '%s' as a superclass of class '%s'", superName.c_str(), declaredExternType->name.value)
                 }
             );
 
@@ -3997,19 +3994,36 @@ ConstraintGenerator::FunctionSignature ConstraintGenerator::checkFunctionSignatu
         AstLocal* local = fn->args.data[i];
 
         TypeId argTy = nullptr;
+        bool hasSpecifiedArgTy = false;
         if (local->annotation)
         {
             argTy = resolveType(signatureScope, local->annotation, /* inTypeArguments */ false, /* replaceErrorWithFresh*/ true, Polarity::Negative);
+            hasSpecifiedArgTy = true;
         }
         else
         {
             if (i < expectedArgPack.head.size())
+            {
                 argTy = expectedArgPack.head[i];
-            else
-                argTy = freshType(signatureScope, Polarity::Negative);
+                hasSpecifiedArgTy = true;
+            }
         }
 
-        argTypes.push_back(argTy);
+        AstExpr* argDefault = fn->argsDefaults.data[i];
+        if (argDefault)
+        {
+            Inference found = check(signatureScope, argDefault, argTy);
+
+            if (hasSpecifiedArgTy)
+                addConstraint(signatureScope, argDefault->location, SubtypeConstraint{found.ty, argTy});
+            else
+                argTy = found.ty;
+        }
+
+        if (!argTy)
+            argTy = freshType(signatureScope, Polarity::Negative);
+
+        argTypes.push_back(argDefault ? makeUnion(signatureScope, argDefault->location, builtinTypes->nilType, argTy) : argTy);
         argNames.emplace_back(FunctionArgument{local->name.value, local->location});
 
         signatureScope->bindings[local] = Binding{argTy, local->location};

--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -50,6 +50,7 @@ LUAU_FASTFLAGVARIABLE(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier)
 LUAU_FLAGVERSION(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier, 2)
 LUAU_FASTFLAGVARIABLE(LuauDeprecatedAttributeOnAnonymousFunctions)
 LUAU_FASTFLAGVARIABLE(DebugLuauCFG)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 namespace Luau
 {
@@ -1140,9 +1141,11 @@ void ConstraintGenerator::prototypeTypeDefinitions(const ScopePtr& scope, AstSta
 
             TypeId instanceMetatable = arena->addType(TableType{instanceMetatableProps, std::nullopt, TypeLevel{}, scope.get(), TableState::Sealed});
 
-            TypeId classInstanceTy = arena->addType(ExternType{
-                declName, std::move(props), builtinTypes->objectType, instanceMetatable, Tags{}, nullptr, module->name, classDecl->location
-            });
+            TypeId classInstanceTy = arena->addType(ExternType
+                {
+                    declName, std::move(props), builtinTypes->objectType, instanceMetatable, Tags{}, nullptr, module->name, classDecl->location
+                }
+            );
 
             TypeId ctorTy =
                 arena->addType(FunctionType{arena->addTypePack({builtinTypes->unknownType, ctorArgTy}), arena->addTypePack({classInstanceTy})});
@@ -2227,7 +2230,8 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatDeclareExte
         {
             reportError(
                 declaredExternType->location,
-                GenericError{format("Cannot use non-class type '%s' as a superclass of class '%s'", superName.c_str(), declaredExternType->name.value)
+                GenericError{
+                    format("Cannot use non-class type '%s' as a superclass of class '%s'", superName.c_str(), declaredExternType->name.value)
                 }
             );
 
@@ -4009,21 +4013,31 @@ ConstraintGenerator::FunctionSignature ConstraintGenerator::checkFunctionSignatu
             }
         }
 
-        AstExpr* argDefault = fn->argsDefaults.data[i];
-        if (argDefault)
+        if (FFlag::LuauDefaultArguments)
         {
-            Inference found = check(signatureScope, argDefault, argTy);
+            AstExpr* argDefault = fn->argsDefaults.data[i];
+            if (argDefault)
+            {
+                Inference found = check(signatureScope, argDefault, argTy);
 
-            if (hasSpecifiedArgTy)
-                addConstraint(signatureScope, argDefault->location, SubtypeConstraint{found.ty, argTy});
-            else
-                argTy = found.ty;
+                if (hasSpecifiedArgTy)
+                    addConstraint(signatureScope, argDefault->location, SubtypeConstraint{found.ty, argTy});
+                else
+                    argTy = found.ty;
+            }
+
+            if (!argTy)
+                argTy = freshType(signatureScope, Polarity::Negative);
+
+            argTypes.push_back(argDefault ? makeUnion(signatureScope, argDefault->location, builtinTypes->nilType, argTy) : argTy);
         }
+        else
+        {
+            if (!argTy)
+                argTy = freshType(signatureScope, Polarity::Negative);
 
-        if (!argTy)
-            argTy = freshType(signatureScope, Polarity::Negative);
-
-        argTypes.push_back(argDefault ? makeUnion(signatureScope, argDefault->location, builtinTypes->nilType, argTy) : argTy);
+            argTypes.push_back(argTy);
+        }
         argNames.emplace_back(FunctionArgument{local->name.value, local->location});
 
         signatureScope->bindings[local] = Binding{argTy, local->location};

--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -1141,8 +1141,8 @@ void ConstraintGenerator::prototypeTypeDefinitions(const ScopePtr& scope, AstSta
 
             TypeId instanceMetatable = arena->addType(TableType{instanceMetatableProps, std::nullopt, TypeLevel{}, scope.get(), TableState::Sealed});
 
-            TypeId classInstanceTy = arena->addType(ExternType
-                {
+            TypeId classInstanceTy = arena->addType(
+                ExternType{
                     declName, std::move(props), builtinTypes->objectType, instanceMetatable, Tags{}, nullptr, module->name, classDecl->location
                 }
             );

--- a/Analysis/src/DataFlowGraph.cpp
+++ b/Analysis/src/DataFlowGraph.cpp
@@ -15,6 +15,7 @@ LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAGVARIABLE(LuauDoNotOverwriteAstDefs)
 LUAU_FASTFLAGVARIABLE(LuauAvoidTrivialPhis)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 namespace Luau
 {
@@ -1152,9 +1153,12 @@ DataFlowResult DataFlowGraphBuilder::visitFunction(AstExprFunction* f, NotNull<D
     if (f->returnAnnotation)
         visitTypePack(f->returnAnnotation);
 
-    for (AstExpr* paramDefault : f->argsDefaults)
-        if (paramDefault)
-            visitExpr(paramDefault);
+    if (FFlag::LuauDefaultArguments)
+    {
+        for (AstExpr* paramDefault : f->argsDefaults)
+            if (paramDefault)
+                visitExpr(paramDefault);
+    }
 
     // TODO: function body can be re-entrant, as in mutations that occurs at the end of the function can also be
     // visible to the beginning of the function, so statically speaking, the body of the function has an exit point

--- a/Analysis/src/DataFlowGraph.cpp
+++ b/Analysis/src/DataFlowGraph.cpp
@@ -1152,6 +1152,10 @@ DataFlowResult DataFlowGraphBuilder::visitFunction(AstExprFunction* f, NotNull<D
     if (f->returnAnnotation)
         visitTypePack(f->returnAnnotation);
 
+    for (AstExpr* paramDefault : f->argsDefaults)
+        if (paramDefault)
+            visitExpr(paramDefault);
+
     // TODO: function body can be re-entrant, as in mutations that occurs at the end of the function can also be
     // visible to the beginning of the function, so statically speaking, the body of the function has an exit point
     // that points back to itself, e.g.

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -2061,8 +2061,10 @@ void TypeChecker2::visit(AstExprFunction* fn)
         if (fn->self)
             ++argIt;
 
-        for (const auto& arg : fn->args)
+        for (size_t i = 0; i < fn->args.size; ++i)
         {
+            const auto& arg = fn->args.data[i];
+
             if (argIt == end(inferredFtv->argTypes))
                 break;
 
@@ -2075,7 +2077,11 @@ void TypeChecker2::visit(AstExprFunction* fn)
 
                 TypeId annotatedArgTy = lookupAnnotation(arg->annotation);
 
-                testIsSubtype(inferredArgTy, annotatedArgTy, arg->location);
+                TypeId argTy = fn->argsDefaults.data[i] ? stripNil(builtinTypes, *module->internalTypes, inferredArgTy) : inferredArgTy;
+                testIsSubtype(argTy, annotatedArgTy, arg->location);
+
+                if (AstExpr* defaultValue = fn->argsDefaults.data[i])
+                    testIsSubtype(lookupType(defaultValue), annotatedArgTy, defaultValue->location);
             }
 
             // Some Luau constructs can result in an argument type being

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -42,6 +42,7 @@ LUAU_FASTFLAG(LuauImproveUniqueTableWidthSubtyping)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
 
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 namespace Luau
 {
@@ -2077,11 +2078,18 @@ void TypeChecker2::visit(AstExprFunction* fn)
 
                 TypeId annotatedArgTy = lookupAnnotation(arg->annotation);
 
-                TypeId argTy = fn->argsDefaults.data[i] ? stripNil(builtinTypes, *module->internalTypes, inferredArgTy) : inferredArgTy;
-                testIsSubtype(argTy, annotatedArgTy, arg->location);
+                if (FFlag::LuauDefaultArguments)
+                {
+                    TypeId argTy = fn->argsDefaults.data[i] ? stripNil(builtinTypes, *module->internalTypes, inferredArgTy) : inferredArgTy;
+                    testIsSubtype(argTy, annotatedArgTy, arg->location);
 
-                if (AstExpr* defaultValue = fn->argsDefaults.data[i])
-                    testIsSubtype(lookupType(defaultValue), annotatedArgTy, defaultValue->location);
+                    if (AstExpr* defaultValue = fn->argsDefaults.data[i])
+                        testIsSubtype(lookupType(defaultValue), annotatedArgTy, defaultValue->location);
+                }
+                else
+                {
+                    testIsSubtype(inferredArgTy, annotatedArgTy, arg->location);
+                }
             }
 
             // Some Luau constructs can result in an argument type being

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -3993,8 +3993,10 @@ std::pair<TypeId, ScopePtr> TypeChecker::checkFunctionSignature(
         expectedArgsEnd = end(expectedFunctionType->argTypes);
     }
 
-    for (AstLocal* local : expr.args)
+    for (size_t i = 0; i < expr.args.size; i++)
     {
+        AstLocal* local = expr.args.data[i];
+
         TypeId argType = nullptr;
 
         if (local->annotation)
@@ -4005,7 +4007,20 @@ std::pair<TypeId, ScopePtr> TypeChecker::checkFunctionSignature(
             if (get<ErrorType>(follow(argType)))
                 argType = anyIfNonstrict(freshType(funScope));
         }
-        else
+        if (expr.argsDefaults.data[i])
+        {
+            // We have a default value, so infer type from that
+            TypeId defaultArgType = checkExpr(funScope, *expr.argsDefaults.data[i]->asExpr()).type;
+            if (get<ErrorType>(follow(defaultArgType)))
+                defaultArgType = anyIfNonstrict(freshType(funScope));
+
+            if (argType == nullptr)
+                argType = defaultArgType;
+            else
+                unify(defaultArgType, argType, scope, expr.argsDefaults.data[i]->location);
+        }
+
+        if (argType == nullptr)
         {
             if (expectedFunctionType && !isNonstrictMode())
             {
@@ -4025,7 +4040,15 @@ std::pair<TypeId, ScopePtr> TypeChecker::checkFunctionSignature(
         }
 
         funScope->bindings[local] = {argType, local->location};
-        argTypes.push_back(argType);
+
+        if (expr.argsDefaults.data[i])
+        {
+            argTypes.push_back(unionOfTypes(nilType, argType, scope, expr.argsDefaults.data[i]->location));
+        }
+        else
+        {
+            argTypes.push_back(argType);
+        }
 
         if (expectedArgsCurr != expectedArgsEnd)
             ++expectedArgsCurr;
@@ -4223,14 +4246,12 @@ void TypeChecker::checkArgumentList(
             namePath = *path;
 
         auto [minParams, optMaxParams] = getParameterExtents(&state.log, paramPack);
-        state.reportError(
-            TypeError{
-                location,
-                CountMismatch{
-                    minParams, optMaxParams, std::distance(begin(argPack), end(argPack)), CountMismatch::Context::Arg, false, std::move(namePath)
-                }
+        state.reportError(TypeError{
+            location,
+            CountMismatch{
+                minParams, optMaxParams, std::distance(begin(argPack), end(argPack)), CountMismatch::Context::Arg, false, std::move(namePath)
             }
-        );
+        });
     };
 
     while (true)
@@ -4347,12 +4368,10 @@ void TypeChecker::checkArgumentList(
                     if (std::optional<std::string> path = getFunctionNameAsString(funName))
                         namePath = *path;
 
-                    state.reportError(
-                        TypeError{
-                            funName.location,
-                            CountMismatch{minParams, optMaxParams, paramIndex, CountMismatch::Context::Arg, isVariadic, std::move(namePath)}
-                        }
-                    );
+                    state.reportError(TypeError{
+                        funName.location,
+                        CountMismatch{minParams, optMaxParams, paramIndex, CountMismatch::Context::Arg, isVariadic, std::move(namePath)}
+                    });
                     return;
                 }
                 ++paramIter;
@@ -4773,14 +4792,12 @@ std::unique_ptr<WithPredicate<TypePackId>> TypeChecker::checkCallOverload(
         else
             overloadsThatDont.push_back(fn);
 
-        errors.push_back(
-            OverloadErrorEntry{
-                std::move(state.log),
-                std::move(state.errors),
-                args->head,
-                ftv,
-            }
-        );
+        errors.push_back(OverloadErrorEntry{
+            std::move(state.log),
+            std::move(state.errors),
+            args->head,
+            ftv,
+        });
     }
     else
     {

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -4251,8 +4251,8 @@ void TypeChecker::checkArgumentList(
             namePath = *path;
 
         auto [minParams, optMaxParams] = getParameterExtents(&state.log, paramPack);
-        state.reportError(TypeError
-            {
+        state.reportError(
+            TypeError{
                 location,
                 CountMismatch{
                     minParams, optMaxParams, std::distance(begin(argPack), end(argPack)), CountMismatch::Context::Arg, false, std::move(namePath)
@@ -4803,8 +4803,7 @@ std::unique_ptr<WithPredicate<TypePackId>> TypeChecker::checkCallOverload(
             overloadsThatDont.push_back(fn);
 
         errors.push_back(
-            OverloadErrorEntry
-            {
+            OverloadErrorEntry{
                 std::move(state.log),
                 std::move(state.errors),
                 args->head,

--- a/Analysis/src/TypeInfer.cpp
+++ b/Analysis/src/TypeInfer.cpp
@@ -33,6 +33,7 @@ LUAU_FASTFLAG(LuauInstantiateInSubtyping)
 LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(LuauExportValueTypecheck)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 namespace Luau
 {
@@ -4007,17 +4008,21 @@ std::pair<TypeId, ScopePtr> TypeChecker::checkFunctionSignature(
             if (get<ErrorType>(follow(argType)))
                 argType = anyIfNonstrict(freshType(funScope));
         }
-        if (expr.argsDefaults.data[i])
-        {
-            // We have a default value, so infer type from that
-            TypeId defaultArgType = checkExpr(funScope, *expr.argsDefaults.data[i]->asExpr()).type;
-            if (get<ErrorType>(follow(defaultArgType)))
-                defaultArgType = anyIfNonstrict(freshType(funScope));
 
-            if (argType == nullptr)
-                argType = defaultArgType;
-            else
-                unify(defaultArgType, argType, scope, expr.argsDefaults.data[i]->location);
+        if (FFlag::LuauDefaultArguments)
+        {
+            if (expr.argsDefaults.data[i])
+            {
+                // We have a default value, so infer type from that
+                TypeId defaultArgType = checkExpr(funScope, *expr.argsDefaults.data[i]->asExpr()).type;
+                if (get<ErrorType>(follow(defaultArgType)))
+                    defaultArgType = anyIfNonstrict(freshType(funScope));
+
+                if (argType == nullptr)
+                    argType = defaultArgType;
+                else
+                    unify(defaultArgType, argType, scope, expr.argsDefaults.data[i]->location);
+            }
         }
 
         if (argType == nullptr)
@@ -4041,7 +4046,7 @@ std::pair<TypeId, ScopePtr> TypeChecker::checkFunctionSignature(
 
         funScope->bindings[local] = {argType, local->location};
 
-        if (expr.argsDefaults.data[i])
+        if (FFlag::LuauDefaultArguments && expr.argsDefaults.data[i])
         {
             argTypes.push_back(unionOfTypes(nilType, argType, scope, expr.argsDefaults.data[i]->location));
         }
@@ -4246,12 +4251,14 @@ void TypeChecker::checkArgumentList(
             namePath = *path;
 
         auto [minParams, optMaxParams] = getParameterExtents(&state.log, paramPack);
-        state.reportError(TypeError{
-            location,
-            CountMismatch{
-                minParams, optMaxParams, std::distance(begin(argPack), end(argPack)), CountMismatch::Context::Arg, false, std::move(namePath)
+        state.reportError(TypeError
+            {
+                location,
+                CountMismatch{
+                    minParams, optMaxParams, std::distance(begin(argPack), end(argPack)), CountMismatch::Context::Arg, false, std::move(namePath)
+                }
             }
-        });
+        );
     };
 
     while (true)
@@ -4368,10 +4375,13 @@ void TypeChecker::checkArgumentList(
                     if (std::optional<std::string> path = getFunctionNameAsString(funName))
                         namePath = *path;
 
-                    state.reportError(TypeError{
-                        funName.location,
-                        CountMismatch{minParams, optMaxParams, paramIndex, CountMismatch::Context::Arg, isVariadic, std::move(namePath)}
-                    });
+                    state.reportError(
+                        TypeError
+                        {
+                            funName.location,
+                            CountMismatch{minParams, optMaxParams, paramIndex, CountMismatch::Context::Arg, isVariadic, std::move(namePath)}
+                        }
+                    );
                     return;
                 }
                 ++paramIter;
@@ -4792,12 +4802,15 @@ std::unique_ptr<WithPredicate<TypePackId>> TypeChecker::checkCallOverload(
         else
             overloadsThatDont.push_back(fn);
 
-        errors.push_back(OverloadErrorEntry{
-            std::move(state.log),
-            std::move(state.errors),
-            args->head,
-            ftv,
-        });
+        errors.push_back(
+            OverloadErrorEntry
+            {
+                std::move(state.log),
+                std::move(state.errors),
+                args->head,
+                ftv,
+            }
+        );
     }
     else
     {

--- a/Ast/include/Luau/Ast.h
+++ b/Ast/include/Luau/Ast.h
@@ -521,6 +521,7 @@ public:
         const AstArray<AstGenericTypePack*>& genericPacks,
         AstLocal* self,
         const AstArray<AstLocal*>& args,
+        const AstArray<AstExpr*>& argsDefaults,
         bool vararg,
         const Location& varargLocation,
         AstStatBlock* body,
@@ -542,6 +543,7 @@ public:
     AstArray<AstGenericTypePack*> genericPacks;
     AstLocal* self;
     AstArray<AstLocal*> args;
+    AstArray<AstExpr*> argsDefaults;
     AstTypePack* returnAnnotation = nullptr;
     bool vararg = false;
     Location varargLocation;

--- a/Ast/include/Luau/Parser.h
+++ b/Ast/include/Luau/Parser.h
@@ -218,11 +218,7 @@ private:
     // var [`+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='] exp
     AstStat* parseCompoundAssignment(AstExpr* initial, AstExprBinary::Op op);
 
-    std::tuple<AstLocal*, AstArray<AstLocal*>, AstArray<AstExpr*>> prepareFunctionArguments(
-        const Location& start,
-        bool hasself,
-        const TempVector<Binding>& args
-    );
+    std::tuple<AstLocal*, AstArray<AstLocal*>, AstArray<AstExpr*>> prepareFunctionArguments(const Location& start, bool hasself, const TempVector<Binding>& args);
 
     // funcbodyhead ::= `(' [namelist [`,' `...'] | `...'] `)' [`:` Type]
     // funcbody ::= funcbodyhead block end
@@ -459,8 +455,12 @@ private:
     // `astErrorLocation` is associated with the AstTypeError created
     // It can be useful to have different error locations so that the parse error can include the next lexeme, while the AstTypeError can precisely
     // define the location (possibly of zero size) where a type annotation is expected.
-    AstTypeError* reportMissingTypeError(const Location& parseErrorLocation, const Location& astErrorLocation, const char* format, ...)
-        LUAU_PRINTF_ATTR(4, 5);
+    AstTypeError* reportMissingTypeError(
+        const Location& parseErrorLocation,
+        const Location& astErrorLocation,
+        const char* format,
+        ...
+    ) LUAU_PRINTF_ATTR(4, 5);
 
     AstExpr* reportFunctionArgsError(AstExpr* func, bool self);
     void reportAmbiguousCallError();

--- a/Ast/include/Luau/Parser.h
+++ b/Ast/include/Luau/Parser.h
@@ -218,7 +218,11 @@ private:
     // var [`+=' | `-=' | `*=' | `/=' | `%=' | `^=' | `..='] exp
     AstStat* parseCompoundAssignment(AstExpr* initial, AstExprBinary::Op op);
 
-    std::pair<AstLocal*, AstArray<AstLocal*>> prepareFunctionArguments(const Location& start, bool hasself, const TempVector<Binding>& args);
+    std::tuple<AstLocal*, AstArray<AstLocal*>, AstArray<AstExpr*>> prepareFunctionArguments(
+        const Location& start,
+        bool hasself,
+        const TempVector<Binding>& args
+    );
 
     // funcbodyhead ::= `(' [namelist [`,' `...'] | `...'] `)' [`:` Type]
     // funcbody ::= funcbodyhead block end
@@ -235,8 +239,8 @@ private:
     // explist ::= {exp `,'} exp
     void parseExprList(TempVector<AstExpr*>& result, TempVector<Position>* commaPositions = nullptr);
 
-    // binding ::= Name [`:` Type]
-    Binding parseBinding(bool isConst = false);
+    // binding ::= Name [`:` Type] [`=` Default]
+    Binding parseBinding(bool isConst = false, bool allowDefault = false);
     AstArray<Position> extractAnnotationColonPositions(const TempVector<Binding>& bindings);
 
     // bindinglist ::= (binding | `...') {`,' bindinglist}
@@ -244,6 +248,7 @@ private:
     std::tuple<bool, Location, AstTypePack*> parseBindingList(
         TempVector<Binding>& result,
         bool allowDot3 = false,
+        bool allowDefault = false,
         AstArray<Position>* commaPositions = nullptr,
         Position* initialCommaPosition = nullptr,
         Position* varargAnnotationColonPosition = nullptr,
@@ -454,12 +459,8 @@ private:
     // `astErrorLocation` is associated with the AstTypeError created
     // It can be useful to have different error locations so that the parse error can include the next lexeme, while the AstTypeError can precisely
     // define the location (possibly of zero size) where a type annotation is expected.
-    AstTypeError* reportMissingTypeError(
-        const Location& parseErrorLocation,
-        const Location& astErrorLocation,
-        const char* format,
-        ...
-    ) LUAU_PRINTF_ATTR(4, 5);
+    AstTypeError* reportMissingTypeError(const Location& parseErrorLocation, const Location& astErrorLocation, const char* format, ...)
+        LUAU_PRINTF_ATTR(4, 5);
 
     AstExpr* reportFunctionArgsError(AstExpr* func, bool self);
     void reportAmbiguousCallError();
@@ -508,12 +509,20 @@ private:
         AstType* annotation;
         Position colonPosition;
         bool isConst;
+        AstExpr* defaultValue;
 
-        explicit Binding(const Name& name, AstType* annotation = nullptr, Position colonPosition = {0, 0}, bool isConst = false)
+        explicit Binding(
+            const Name& name,
+            AstType* annotation = nullptr,
+            Position colonPosition = {0, 0},
+            bool isConst = false,
+            AstExpr* defaultValue = nullptr
+        )
             : name(name)
             , annotation(annotation)
             , colonPosition(colonPosition)
             , isConst(isConst)
+            , defaultValue(defaultValue)
         {
         }
     };

--- a/Ast/src/Ast.cpp
+++ b/Ast/src/Ast.cpp
@@ -3,6 +3,7 @@
 
 #include "Luau/Common.h"
 
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 namespace Luau
 {
@@ -345,10 +346,13 @@ void AstExprFunction::visit(AstVisitor* visitor)
                 arg->annotation->visit(visitor);
         }
 
-        for (AstExpr* argDefault : argsDefaults)
+        if (FFlag::LuauDefaultArguments)
         {
-            if (argDefault)
-                argDefault->visit(visitor);
+            for (AstExpr* argDefault : argsDefaults)
+            {
+                if (argDefault)
+                    argDefault->visit(visitor);
+            }
         }
 
         if (varargAnnotation)

--- a/Ast/src/Ast.cpp
+++ b/Ast/src/Ast.cpp
@@ -345,6 +345,12 @@ void AstExprFunction::visit(AstVisitor* visitor)
                 arg->annotation->visit(visitor);
         }
 
+        for (AstExpr* argDefault : argsDefaults)
+        {
+            if (argDefault)
+                argDefault->visit(visitor);
+        }
+
         if (varargAnnotation)
             varargAnnotation->visit(visitor);
 

--- a/Ast/src/Ast.cpp
+++ b/Ast/src/Ast.cpp
@@ -307,6 +307,7 @@ AstExprFunction::AstExprFunction(
     const AstArray<AstGenericTypePack*>& genericPacks,
     AstLocal* self,
     const AstArray<AstLocal*>& args,
+    const AstArray<AstExpr*>& argsDefaults,
     bool vararg,
     const Location& varargLocation,
     AstStatBlock* body,
@@ -322,6 +323,7 @@ AstExprFunction::AstExprFunction(
     , genericPacks(genericPacks)
     , self(self)
     , args(args)
+    , argsDefaults(argsDefaults)
     , returnAnnotation(returnAnnotation)
     , vararg(vararg)
     , varargLocation(varargLocation)

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -34,6 +34,7 @@ LUAU_FASTFLAGVARIABLE(LuauCstAttr)
 LUAU_FASTFLAGVARIABLE(LuauStoreConstKeywordBegin)
 LUAU_FASTFLAGVARIABLE(LuauNoDuplicateBinaryPrefix)
 LUAU_FASTFLAGVARIABLE(LuauTrackPrefixLocal)
+LUAU_FASTFLAGVARIABLE(DebugLuauDefaultArguments)
 
 // Clip with DebugLuauReportReturnTypeVariadicWithTypeSuffix
 bool luau_telemetry_parsed_return_type_variadic_with_type_suffix = false;
@@ -1781,7 +1782,7 @@ AstDeclaredExternTypeProperty Parser::parseDeclaredExternTypeMethod(const AstArr
     Location varargLocation;
     AstTypePack* varargAnnotation = nullptr;
     if (lexer.current().type != ')')
-        std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3 */ true, /* allowDefault= */ true);
+        std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3 */ true, /* allowDefault= */ false);
 
     expectMatchAndConsume(')', matchParen);
 
@@ -1852,7 +1853,7 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
         AstTypePack* varargAnnotation = nullptr;
 
         if (lexer.current().type != ')')
-            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true, /* allowDefault= */ true);
+            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true, /* allowDefault= */ false);
 
         expectMatchAndConsume(')', matchParen);
 
@@ -2330,10 +2331,16 @@ std::pair<AstExprFunction*, AstLocal*> Parser::parseFunctionBody(
     {
         if (cstNode)
             std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(
-                args, /* allowDot3= */ true, /* allowDefault= */ true, &cstNode->argsCommaPositions, nullptr, &cstNode->varargAnnotationColonPosition
+                args,
+                /* allowDot3= */ true,
+                /* allowDefault= */ FFlag::DebugLuauDefaultArguments,
+                &cstNode->argsCommaPositions,
+                nullptr,
+                &cstNode->varargAnnotationColonPosition
             );
         else
-            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true, /* allowDefault= */ true);
+            std::tie(vararg, varargLocation, varargAnnotation) =
+                parseBindingList(args, /* allowDot3= */ true, /* allowDefault= */ FFlag::DebugLuauDefaultArguments);
     }
 
     std::optional<Location> argLocation;

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -34,7 +34,7 @@ LUAU_FASTFLAGVARIABLE(LuauCstAttr)
 LUAU_FASTFLAGVARIABLE(LuauStoreConstKeywordBegin)
 LUAU_FASTFLAGVARIABLE(LuauNoDuplicateBinaryPrefix)
 LUAU_FASTFLAGVARIABLE(LuauTrackPrefixLocal)
-LUAU_FASTFLAGVARIABLE(DebugLuauDefaultArguments)
+LUAU_FASTFLAGVARIABLE(LuauDefaultArguments)
 
 // Clip with DebugLuauReportReturnTypeVariadicWithTypeSuffix
 bool luau_telemetry_parsed_return_type_variadic_with_type_suffix = false;
@@ -1167,7 +1167,8 @@ void Parser::parseAttribute_DEPRECATED(TempVector<AstAttr*>& attributes)
             report(Location(open.location, lexer.current().location), "Attribute list cannot be empty");
 
             // autocomplete expects at least one unknown attribute.
-            attributes.push_back(allocator.alloc<AstAttr>(Location(open.location, lexer.current().location), AstAttr::Type::Unknown, empty, nameError)
+            attributes.push_back(
+                allocator.alloc<AstAttr>(Location(open.location, lexer.current().location), AstAttr::Type::Unknown, empty, nameError)
             );
         }
 
@@ -1626,13 +1627,16 @@ LUAU_NOINLINE AstStat* Parser::parseClassStat(const Location& start, bool export
 
                 // Either both of these are present or neither are.
                 LUAU_ASSERT((bool)propType == (bool)typeColonLocation);
-                declarations.push_back(AstClassProperty{
-                    *qualifierLocation,
-                    propName->name,
-                    propName->location,
-                    typeColonLocation,
-                    propType,
-                });
+                declarations.push_back(
+                    AstClassProperty
+                    {
+                        *qualifierLocation,
+                        propName->name,
+                        propName->location,
+                        typeColonLocation,
+                        propType,
+                    }
+                );
             }
         }
         else if (lexer.current().type == Lexeme::ReservedFunction)
@@ -1680,13 +1684,16 @@ LUAU_NOINLINE AstStat* Parser::parseClassStat(const Location& start, bool export
             {
                 classMemberNamespace.insert(name.name);
 
-                declarations.push_back(AstClassMethod{
-                    qualifierLocation,
-                    matchFunction.location,
-                    name.name,
-                    name.location,
-                    body,
-                });
+                declarations.push_back(
+                    AstClassMethod
+                    {
+                        qualifierLocation,
+                        matchFunction.location,
+                        name.name,
+                        name.location,
+                        body,
+                    }
+                );
             }
         }
         else
@@ -1985,9 +1992,11 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
 
                     if (chars && !containsNull)
                     {
-                        props.push_back(AstDeclaredExternTypeProperty{
-                            AstName(chars->data), Location(nameBegin, nameEnd), type, false, Location(begin.location, lexer.previousLocation())
-                        });
+                        props.push_back(AstDeclaredExternTypeProperty
+                            {
+                                AstName(chars->data), Location(nameBegin, nameEnd), type, false, Location(begin.location, lexer.previousLocation())
+                            }
+                        );
                     }
                     else
                     {
@@ -2039,9 +2048,11 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
 
                 expectAndConsume(':', "property type annotation");
                 AstType* propType = parseType();
-                props.push_back(AstDeclaredExternTypeProperty{
-                    propName->name, propName->location, propType, false, Location(propStart, lexer.previousLocation()), access
-                });
+                props.push_back(
+                    AstDeclaredExternTypeProperty{
+                        propName->name, propName->location, propType, false, Location(propStart, lexer.previousLocation()), access
+                    }
+                );
             }
         }
 
@@ -2252,11 +2263,7 @@ AstStat* Parser::parseCompoundAssignment(AstExpr* initial, AstExprBinary::Op op)
     return node;
 }
 
-std::tuple<AstLocal*, AstArray<AstLocal*>, AstArray<AstExpr*>> Parser::prepareFunctionArguments(
-    const Location& start,
-    bool hasself,
-    const TempVector<Binding>& args
-)
+std::tuple<AstLocal*, AstArray<AstLocal*>, AstArray<AstExpr*>> Parser::prepareFunctionArguments(const Location& start, bool hasself, const TempVector<Binding>& args)
 {
     AstLocal* self = nullptr;
 
@@ -2333,14 +2340,14 @@ std::pair<AstExprFunction*, AstLocal*> Parser::parseFunctionBody(
             std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(
                 args,
                 /* allowDot3= */ true,
-                /* allowDefault= */ FFlag::DebugLuauDefaultArguments,
+                /* allowDefault= */ FFlag::LuauDefaultArguments,
                 &cstNode->argsCommaPositions,
                 nullptr,
                 &cstNode->varargAnnotationColonPosition
             );
         else
             std::tie(vararg, varargLocation, varargAnnotation) =
-                parseBindingList(args, /* allowDot3= */ true, /* allowDefault= */ FFlag::DebugLuauDefaultArguments);
+                parseBindingList(args, /* allowDot3= */ true, /* allowDefault= */ FFlag::LuauDefaultArguments);
     }
 
     std::optional<Location> argLocation;
@@ -2444,8 +2451,14 @@ Parser::Binding Parser::parseBinding(bool isConst, bool allowDefault)
     if (allowDefault && lexer.current().type == '=')
     {
         nextLexeme();
-        static Function dummy_fun;
-        functionStack.emplace_back(dummy_fun);
+        // The depth of functionStack is used to determine the scoping for a local
+        // The expressions for default arguments need scoped to the function body, not the parent
+        // scope
+        // We can't access the Function for the body, because that gets constructed during a later
+        // parse step. A dummy function is safe to use here, as code only inspects .vararg and ...
+        // is not legal in a default argument expression.
+        static Function dummyFunction;
+        functionStack.emplace_back(dummyFunction);
 
         defaultValue = parseExpr();
 
@@ -2853,16 +2866,18 @@ AstType* Parser::parseTableType(bool inDeclarationContext)
                     if (options.storeCstData)
                     {
                         CstExprTable::Separator separator = tableSeparator();
-                        cstItems.push_back(CstTypeTable::Item{
-                            CstTypeTable::Item::Kind::StringProperty,
-                            begin.location.begin,
-                            indexerClosePosition,
-                            colonPosition,
-                            separator,
-                            separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
-                            allocator.alloc<CstExprConstantString>(sourceString, style, blockDepth),
-                            stringPosition
-                        });
+                        cstItems.push_back(
+                            CstTypeTable::Item{
+                                CstTypeTable::Item::Kind::StringProperty,
+                                begin.location.begin,
+                                indexerClosePosition,
+                                colonPosition,
+                                separator,
+                                separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
+                                allocator.alloc<CstExprConstantString>(sourceString, style, blockDepth),
+                                stringPosition
+                            }
+                        );
                     }
                 }
                 else
@@ -2886,14 +2901,16 @@ AstType* Parser::parseTableType(bool inDeclarationContext)
                     if (options.storeCstData)
                     {
                         CstExprTable::Separator separator = tableSeparator();
-                        cstItems.push_back(CstTypeTable::Item{
-                            CstTypeTable::Item::Kind::Indexer,
-                            tableIndexerResult.indexerOpenPosition,
-                            tableIndexerResult.indexerClosePosition,
-                            tableIndexerResult.colonPosition,
-                            separator,
-                            separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
-                        });
+                        cstItems.push_back(
+                            CstTypeTable::Item{
+                                CstTypeTable::Item::Kind::Indexer,
+                                tableIndexerResult.indexerOpenPosition,
+                                tableIndexerResult.indexerClosePosition,
+                                tableIndexerResult.colonPosition,
+                                separator,
+                                separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
+                            }
+                        );
                     }
                 }
             }
@@ -2925,14 +2942,16 @@ AstType* Parser::parseTableType(bool inDeclarationContext)
             if (options.storeCstData)
             {
                 CstExprTable::Separator separator = tableSeparator();
-                cstItems.push_back(CstTypeTable::Item{
-                    CstTypeTable::Item::Kind::Property,
-                    Position::missing(),
-                    Position::missing(),
-                    colonPosition,
-                    separator,
-                    separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
-                });
+                cstItems.push_back(
+                    CstTypeTable::Item{
+                        CstTypeTable::Item::Kind::Property,
+                        Position::missing(),
+                        Position::missing(),
+                        colonPosition,
+                        separator,
+                        separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
+                    }
+                );
             }
         }
 
@@ -3405,9 +3424,8 @@ AstTypeOrPack Parser::parseSimpleType(bool allowPack, bool inDeclarationContext)
 
         Location end = lexer.previousLocation();
 
-        AstTypeReference* node = allocator.alloc<AstTypeReference>(
-            Location(start, end), prefix, name.name, prefixLocation, name.location, hasParameters, parameters, prefixLocal
-        );
+        AstTypeReference* node =
+            allocator.alloc<AstTypeReference>(Location(start, end), prefix, name.name, prefixLocation, name.location, hasParameters, parameters, prefixLocal);
         if (options.storeCstData)
             cstNodeMap[node] = allocator.alloc<CstTypeReference>(
                 prefixPointPosition, parametersOpeningPosition, copy(parametersCommaPositions), parametersClosingPosition

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -1628,8 +1628,7 @@ LUAU_NOINLINE AstStat* Parser::parseClassStat(const Location& start, bool export
                 // Either both of these are present or neither are.
                 LUAU_ASSERT((bool)propType == (bool)typeColonLocation);
                 declarations.push_back(
-                    AstClassProperty
-                    {
+                    AstClassProperty{
                         *qualifierLocation,
                         propName->name,
                         propName->location,
@@ -1685,8 +1684,7 @@ LUAU_NOINLINE AstStat* Parser::parseClassStat(const Location& start, bool export
                 classMemberNamespace.insert(name.name);
 
                 declarations.push_back(
-                    AstClassMethod
-                    {
+                    AstClassMethod{
                         qualifierLocation,
                         matchFunction.location,
                         name.name,
@@ -1992,8 +1990,8 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
 
                     if (chars && !containsNull)
                     {
-                        props.push_back(AstDeclaredExternTypeProperty
-                            {
+                        props.push_back(
+                            AstDeclaredExternTypeProperty{
                                 AstName(chars->data), Location(nameBegin, nameEnd), type, false, Location(begin.location, lexer.previousLocation())
                             }
                         );

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -790,7 +790,7 @@ AstStat* Parser::parseFor()
             {
                 Position initialCommaPosition = lexer.current().location.begin;
                 nextLexeme();
-                parseBindingList(names, false, &varsCommaPosition, &initialCommaPosition);
+                parseBindingList(names, false, false, &varsCommaPosition, &initialCommaPosition);
             }
             else
             {
@@ -1166,8 +1166,7 @@ void Parser::parseAttribute_DEPRECATED(TempVector<AstAttr*>& attributes)
             report(Location(open.location, lexer.current().location), "Attribute list cannot be empty");
 
             // autocomplete expects at least one unknown attribute.
-            attributes.push_back(
-                allocator.alloc<AstAttr>(Location(open.location, lexer.current().location), AstAttr::Type::Unknown, empty, nameError)
+            attributes.push_back(allocator.alloc<AstAttr>(Location(open.location, lexer.current().location), AstAttr::Type::Unknown, empty, nameError)
             );
         }
 
@@ -1403,9 +1402,9 @@ AstStat* Parser::parseLocal(
         TempVector<Binding> names(scratchBinding);
         AstArray<Position> varsCommaPositions;
         if (options.storeCstData)
-            parseBindingList(names, false, &varsCommaPositions, nullptr, nullptr, isConst);
+            parseBindingList(names, false, false, &varsCommaPositions, nullptr, nullptr, isConst);
         else
-            parseBindingList(names, false, nullptr, nullptr, nullptr, isConst);
+            parseBindingList(names, false, false, nullptr, nullptr, nullptr, isConst);
 
         matchRecoveryStopOnToken['=']--;
 
@@ -1626,15 +1625,13 @@ LUAU_NOINLINE AstStat* Parser::parseClassStat(const Location& start, bool export
 
                 // Either both of these are present or neither are.
                 LUAU_ASSERT((bool)propType == (bool)typeColonLocation);
-                declarations.push_back(
-                    AstClassProperty{
-                        *qualifierLocation,
-                        propName->name,
-                        propName->location,
-                        typeColonLocation,
-                        propType,
-                    }
-                );
+                declarations.push_back(AstClassProperty{
+                    *qualifierLocation,
+                    propName->name,
+                    propName->location,
+                    typeColonLocation,
+                    propType,
+                });
             }
         }
         else if (lexer.current().type == Lexeme::ReservedFunction)
@@ -1682,15 +1679,13 @@ LUAU_NOINLINE AstStat* Parser::parseClassStat(const Location& start, bool export
             {
                 classMemberNamespace.insert(name.name);
 
-                declarations.push_back(
-                    AstClassMethod{
-                        qualifierLocation,
-                        matchFunction.location,
-                        name.name,
-                        name.location,
-                        body,
-                    }
-                );
+                declarations.push_back(AstClassMethod{
+                    qualifierLocation,
+                    matchFunction.location,
+                    name.name,
+                    name.location,
+                    body,
+                });
             }
         }
         else
@@ -1786,7 +1781,7 @@ AstDeclaredExternTypeProperty Parser::parseDeclaredExternTypeMethod(const AstArr
     Location varargLocation;
     AstTypePack* varargAnnotation = nullptr;
     if (lexer.current().type != ')')
-        std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3 */ true);
+        std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3 */ true, /* allowDefault= */ true);
 
     expectMatchAndConsume(')', matchParen);
 
@@ -1857,7 +1852,7 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
         AstTypePack* varargAnnotation = nullptr;
 
         if (lexer.current().type != ')')
-            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true);
+            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true, /* allowDefault= */ true);
 
         expectMatchAndConsume(')', matchParen);
 
@@ -1989,11 +1984,9 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
 
                     if (chars && !containsNull)
                     {
-                        props.push_back(
-                            AstDeclaredExternTypeProperty{
-                                AstName(chars->data), Location(nameBegin, nameEnd), type, false, Location(begin.location, lexer.previousLocation())
-                            }
-                        );
+                        props.push_back(AstDeclaredExternTypeProperty{
+                            AstName(chars->data), Location(nameBegin, nameEnd), type, false, Location(begin.location, lexer.previousLocation())
+                        });
                     }
                     else
                     {
@@ -2045,11 +2038,9 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
 
                 expectAndConsume(':', "property type annotation");
                 AstType* propType = parseType();
-                props.push_back(
-                    AstDeclaredExternTypeProperty{
-                        propName->name, propName->location, propType, false, Location(propStart, lexer.previousLocation()), access
-                    }
-                );
+                props.push_back(AstDeclaredExternTypeProperty{
+                    propName->name, propName->location, propType, false, Location(propStart, lexer.previousLocation()), access
+                });
             }
         }
 
@@ -2260,7 +2251,11 @@ AstStat* Parser::parseCompoundAssignment(AstExpr* initial, AstExprBinary::Op op)
     return node;
 }
 
-std::pair<AstLocal*, AstArray<AstLocal*>> Parser::prepareFunctionArguments(const Location& start, bool hasself, const TempVector<Binding>& args)
+std::tuple<AstLocal*, AstArray<AstLocal*>, AstArray<AstExpr*>> Parser::prepareFunctionArguments(
+    const Location& start,
+    bool hasself,
+    const TempVector<Binding>& args
+)
 {
     AstLocal* self = nullptr;
 
@@ -2268,11 +2263,15 @@ std::pair<AstLocal*, AstArray<AstLocal*>> Parser::prepareFunctionArguments(const
         self = pushLocal(Binding(Name(nameSelf, start), nullptr));
 
     TempVector<AstLocal*> vars(scratchLocal);
+    TempVector<AstExpr*> varsDefaults(scratchExpr);
 
     for (size_t i = 0; i < args.size(); ++i)
+    {
         vars.push_back(pushLocal(args[i]));
+        varsDefaults.push_back(args[i].defaultValue);
+    }
 
-    return {self, copy(vars)};
+    return {self, copy(vars), copy(varsDefaults)};
 }
 
 // funcbody ::= `(' [parlist] `)' [`:' ReturnType] block end
@@ -2330,10 +2329,11 @@ std::pair<AstExprFunction*, AstLocal*> Parser::parseFunctionBody(
     if (lexer.current().type != ')')
     {
         if (cstNode)
-            std::tie(vararg, varargLocation, varargAnnotation) =
-                parseBindingList(args, /* allowDot3= */ true, &cstNode->argsCommaPositions, nullptr, &cstNode->varargAnnotationColonPosition);
+            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(
+                args, /* allowDot3= */ true, /* allowDefault= */ true, &cstNode->argsCommaPositions, nullptr, &cstNode->varargAnnotationColonPosition
+            );
         else
-            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true);
+            std::tie(vararg, varargLocation, varargAnnotation) = parseBindingList(args, /* allowDot3= */ true, /* allowDefault= */ true);
     }
 
     std::optional<Location> argLocation;
@@ -2361,7 +2361,7 @@ std::pair<AstExprFunction*, AstLocal*> Parser::parseFunctionBody(
 
     functionStack.emplace_back(fun);
 
-    auto [self, vars] = prepareFunctionArguments(start, hasself, args);
+    auto [self, vars, varsDefaults] = prepareFunctionArguments(start, hasself, args);
 
     AstStatBlock* body = parseBlock();
 
@@ -2381,6 +2381,7 @@ std::pair<AstExprFunction*, AstLocal*> Parser::parseFunctionBody(
         genericPacks,
         self,
         vars,
+        varsDefaults,
         vararg,
         varargLocation,
         body,
@@ -2421,7 +2422,7 @@ void Parser::parseExprList(TempVector<AstExpr*>& result, TempVector<Position>* c
     }
 }
 
-Parser::Binding Parser::parseBinding(bool isConst)
+Parser::Binding Parser::parseBinding(bool isConst, bool allowDefault)
 {
     std::optional<Name> name = parseNameOpt("variable name");
 
@@ -2432,10 +2433,22 @@ Parser::Binding Parser::parseBinding(bool isConst)
     Position colonPosition = lexer.current().type == ':' ? lexer.current().location.begin : Position::missing();
     AstType* annotation = parseOptionalType();
 
+    AstExpr* defaultValue = nullptr;
+    if (allowDefault && lexer.current().type == '=')
+    {
+        nextLexeme();
+        static Function dummy_fun;
+        functionStack.emplace_back(dummy_fun);
+
+        defaultValue = parseExpr();
+
+        functionStack.pop_back();
+    }
+
     if (options.storeCstData)
-        return Binding(*name, annotation, colonPosition, isConst);
+        return Binding(*name, annotation, colonPosition, isConst, defaultValue);
     else
-        return Binding(*name, annotation, Position::missing(), isConst);
+        return Binding(*name, annotation, Position::missing(), isConst, defaultValue);
 }
 
 AstArray<Position> Parser::extractAnnotationColonPositions(const TempVector<Binding>& bindings)
@@ -2450,6 +2463,7 @@ AstArray<Position> Parser::extractAnnotationColonPositions(const TempVector<Bind
 LUAU_NOINLINE std::tuple<bool, Location, AstTypePack*> Parser::parseBindingList(
     TempVector<Binding>& result,
     bool allowDot3,
+    bool allowDefault,
     AstArray<Position>* commaPositions,
     Position* initialCommaPosition,
     Position* varargAnnotationColonPosition,
@@ -2484,7 +2498,7 @@ LUAU_NOINLINE std::tuple<bool, Location, AstTypePack*> Parser::parseBindingList(
             return {true, varargLocation, tailAnnotation};
         }
 
-        result.push_back(parseBinding(isConst));
+        result.push_back(parseBinding(isConst, allowDefault));
 
         if (lexer.current().type != ',')
             break;
@@ -2832,18 +2846,16 @@ AstType* Parser::parseTableType(bool inDeclarationContext)
                     if (options.storeCstData)
                     {
                         CstExprTable::Separator separator = tableSeparator();
-                        cstItems.push_back(
-                            CstTypeTable::Item{
-                                CstTypeTable::Item::Kind::StringProperty,
-                                begin.location.begin,
-                                indexerClosePosition,
-                                colonPosition,
-                                separator,
-                                separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
-                                allocator.alloc<CstExprConstantString>(sourceString, style, blockDepth),
-                                stringPosition
-                            }
-                        );
+                        cstItems.push_back(CstTypeTable::Item{
+                            CstTypeTable::Item::Kind::StringProperty,
+                            begin.location.begin,
+                            indexerClosePosition,
+                            colonPosition,
+                            separator,
+                            separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
+                            allocator.alloc<CstExprConstantString>(sourceString, style, blockDepth),
+                            stringPosition
+                        });
                     }
                 }
                 else
@@ -2867,16 +2879,14 @@ AstType* Parser::parseTableType(bool inDeclarationContext)
                     if (options.storeCstData)
                     {
                         CstExprTable::Separator separator = tableSeparator();
-                        cstItems.push_back(
-                            CstTypeTable::Item{
-                                CstTypeTable::Item::Kind::Indexer,
-                                tableIndexerResult.indexerOpenPosition,
-                                tableIndexerResult.indexerClosePosition,
-                                tableIndexerResult.colonPosition,
-                                separator,
-                                separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
-                            }
-                        );
+                        cstItems.push_back(CstTypeTable::Item{
+                            CstTypeTable::Item::Kind::Indexer,
+                            tableIndexerResult.indexerOpenPosition,
+                            tableIndexerResult.indexerClosePosition,
+                            tableIndexerResult.colonPosition,
+                            separator,
+                            separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
+                        });
                     }
                 }
             }
@@ -2908,16 +2918,14 @@ AstType* Parser::parseTableType(bool inDeclarationContext)
             if (options.storeCstData)
             {
                 CstExprTable::Separator separator = tableSeparator();
-                cstItems.push_back(
-                    CstTypeTable::Item{
-                        CstTypeTable::Item::Kind::Property,
-                        Position::missing(),
-                        Position::missing(),
-                        colonPosition,
-                        separator,
-                        separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
-                    }
-                );
+                cstItems.push_back(CstTypeTable::Item{
+                    CstTypeTable::Item::Kind::Property,
+                    Position::missing(),
+                    Position::missing(),
+                    colonPosition,
+                    separator,
+                    separator != CstExprTable::Separator::Missing ? lexer.current().location.begin : Position::missing(),
+                });
             }
         }
 
@@ -3390,8 +3398,9 @@ AstTypeOrPack Parser::parseSimpleType(bool allowPack, bool inDeclarationContext)
 
         Location end = lexer.previousLocation();
 
-        AstTypeReference* node =
-            allocator.alloc<AstTypeReference>(Location(start, end), prefix, name.name, prefixLocation, name.location, hasParameters, parameters, prefixLocal);
+        AstTypeReference* node = allocator.alloc<AstTypeReference>(
+            Location(start, end), prefix, name.name, prefixLocation, name.location, hasParameters, parameters, prefixLocal
+        );
         if (options.storeCstData)
             cstNodeMap[node] = allocator.alloc<CstTypeReference>(
                 prefixPointPosition, parametersOpeningPosition, copy(parametersCommaPositions), parametersClosingPosition

--- a/Ast/src/PrettyPrinter.cpp
+++ b/Ast/src/PrettyPrinter.cpp
@@ -1505,6 +1505,13 @@ struct Printer
 
                 visualizeTypeAnnotation(*local->annotation);
             }
+
+            if (AstExpr* defaultValue = func.argsDefaults.data[i])
+            {
+                writer.maybeSpace(defaultValue->location.begin, 2);
+                writer.symbol("=");
+                visualize(*defaultValue);
+            }
         }
 
         if (func.vararg)

--- a/Ast/src/PrettyPrinter.cpp
+++ b/Ast/src/PrettyPrinter.cpp
@@ -14,6 +14,7 @@ LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauExportValueSyntax)
 
 LUAU_FASTFLAG(LuauCstAttr)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 namespace
 {
@@ -1506,11 +1507,14 @@ struct Printer
                 visualizeTypeAnnotation(*local->annotation);
             }
 
-            if (AstExpr* defaultValue = func.argsDefaults.data[i])
+            if (FFlag::LuauDefaultArguments)
             {
-                writer.maybeSpace(defaultValue->location.begin, 2);
-                writer.symbol("=");
-                visualize(*defaultValue);
+                if (AstExpr* defaultValue = func.argsDefaults.data[i])
+                {
+                    writer.maybeSpace(defaultValue->location.begin, 2);
+                    writer.symbol("=");
+                    visualize(*defaultValue);
+                }
             }
         }
 

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -380,6 +380,33 @@ struct Compiler
         bytecode.emitABC(LOP_RETURN, freezeReg, 2, 0);
     }
 
+    void compileFunctionArgDefaults(AstExprFunction* func)
+    {
+        for (size_t i = 0; i < func->argsDefaults.size; ++i)
+        {
+            AstExpr* defaultValue = func->argsDefaults.data[i];
+            if (defaultValue == nullptr)
+                continue;
+
+            // Guaranteed to have been allocated by the caller.
+            Local* l = locals.find(func->args.data[i]);
+            LUAU_ASSERT(l && l->allocated);
+
+            size_t jumpLabel = bytecode.emitLabel();
+            // Compare our register to nil.
+            bytecode.emitAD(LOP_JUMPXEQKNIL, l->reg, 0);
+            // Invert condition.
+            bytecode.emitAux(0 | 0x80000000);
+
+            { // Make a new scope to save on registers.
+                RegScope rs_expr(this);
+                compileExpr(defaultValue, l->reg, true);
+            }
+
+            patchJump(defaultValue, jumpLabel, bytecode.emitLabel());
+        }
+    }
+
     uint32_t compileFunction(AstExprFunction* func, uint8_t& protoflags)
     {
         LUAU_TIMETRACE_SCOPE("Compiler::compileFunction", "Compiler");
@@ -412,28 +439,7 @@ struct Compiler
 
         argCount = localStack.size();
 
-        for (size_t i = 0; i < func->argsDefaults.size; ++i)
-        {
-            AstExpr* defaultValue = func->argsDefaults.data[i];
-            if (defaultValue == nullptr)
-                continue;
-
-            // Guaranteed to have been allocated due to pushLocal above
-            Local* l = locals.find(func->args.data[i]);
-
-            size_t jumpLabel = bytecode.emitLabel();
-            // Compare our register to nil
-            bytecode.emitAD(LOP_JUMPXEQKNIL, l->reg, 0);
-            // Invert condition
-            bytecode.emitAux(0 | 0x80000000);
-
-            { // Make a new scope to save on registers
-                RegScope rs_expr(this);
-                compileExpr(defaultValue, l->reg, true);
-            }
-
-            patchJump(defaultValue, jumpLabel, bytecode.emitLabel());
-        }
+        compileFunctionArgDefaults(func);
 
         AstStatBlock* stat = func->body;
 
@@ -974,6 +980,16 @@ struct Compiler
         std::vector<InlineArg> args;
         args.reserve(func->args.size);
 
+        bool hasArgDefaults = false;
+        for (AstExpr* defaultValue : func->argsDefaults)
+        {
+            if (defaultValue)
+            {
+                hasArgDefaults = true;
+                break;
+            }
+        }
+
         // evaluate all arguments; note that we don't emit code for constant arguments (relying on constant folding)
         // note that compiler state (variable registers/values) does not change here - we defer that to a separate loop below to handle nested calls
         for (size_t i = 0; i < func->args.size; ++i)
@@ -1001,47 +1017,54 @@ struct Compiler
                 // all remaining function arguments have been allocated and assigned to
                 break;
             }
-            else if (Variable* vv = variables.find(var); vv && vv->written)
-            {
-                // if the argument is mutated, we need to allocate a fresh register even if it's a constant
-                uint8_t reg = allocReg(arg, 1u);
-                uint32_t allocpc = bytecode.getDebugPC();
-
-                if (arg)
-                    compileExprTemp(arg, reg);
-                else
-                    bytecode.emitABC(LOP_LOADNIL, reg, 0, 0);
-
-                args.push_back({var, reg, {Constant::Type_Unknown}, allocpc});
-            }
-            else if (arg == nullptr)
-            {
-                // since the argument is not mutated, we can simply fold the value into the expressions that need it
-                args.push_back({var, kInvalidReg, {Constant::Type_Nil}});
-            }
-            else if (const Constant* cv = constants.find(arg); cv && cv->type != Constant::Type_Unknown)
-            {
-                // since the argument is not mutated, we can simply fold the value into the expressions that need it
-                args.push_back({var, kInvalidReg, *cv});
-            }
             else
             {
-                AstExprLocal* le = getExprLocal(arg);
-                Variable* lv = le ? variables.find(le->local) : nullptr;
+                Variable* vv = variables.find(var);
 
-                // if the argument is a local that isn't mutated, we will simply reuse the existing register
-                if (int reg = le ? getExprLocalReg(le) : -1; reg >= 0 && (!lv || !lv->written))
+                if (hasArgDefaults || (vv && vv->written))
                 {
-                    args.push_back({var, uint8_t(reg), {Constant::Type_Unknown}, kDefaultAllocPc, lv ? lv->init : nullptr});
+                    // If the argument is mutated or this function has default values, we need to allocate a fresh register even if it's a constant.
+                    // Default values assign into parameter registers and can reference other parameters, so reusing a caller local or folding a
+                    // parameter into locstants could mutate caller state or leave default expressions unable to reference parameters.
+                    uint8_t reg = allocReg(arg, 1u);
+                    uint32_t allocpc = bytecode.getDebugPC();
+
+                    if (arg)
+                        compileExprTemp(arg, reg);
+                    else
+                        bytecode.emitABC(LOP_LOADNIL, reg, 0, 0);
+
+                    args.push_back({var, reg, {Constant::Type_Unknown}, allocpc});
+                }
+                else if (arg == nullptr)
+                {
+                    // since the argument is not mutated, we can simply fold the value into the expressions that need it
+                    args.push_back({var, kInvalidReg, {Constant::Type_Nil}});
+                }
+                else if (const Constant* cv = constants.find(arg); cv && cv->type != Constant::Type_Unknown)
+                {
+                    // since the argument is not mutated, we can simply fold the value into the expressions that need it
+                    args.push_back({var, kInvalidReg, *cv});
                 }
                 else
                 {
-                    uint8_t temp = allocReg(arg, 1u);
-                    uint32_t allocpc = bytecode.getDebugPC();
+                    AstExprLocal* le = getExprLocal(arg);
+                    Variable* lv = le ? variables.find(le->local) : nullptr;
 
-                    compileExprTemp(arg, temp);
+                    // if the argument is a local that isn't mutated, we will simply reuse the existing register
+                    if (int reg = le ? getExprLocalReg(le) : -1; reg >= 0 && (!lv || !lv->written))
+                    {
+                        args.push_back({var, uint8_t(reg), {Constant::Type_Unknown}, kDefaultAllocPc, lv ? lv->init : nullptr});
+                    }
+                    else
+                    {
+                        uint8_t temp = allocReg(arg, 1u);
+                        uint32_t allocpc = bytecode.getDebugPC();
 
-                    args.push_back({var, temp, {Constant::Type_Unknown}, allocpc, arg});
+                        compileExprTemp(arg, temp);
+
+                        args.push_back({var, temp, {Constant::Type_Unknown}, allocpc, arg});
+                    }
                 }
             }
         }
@@ -1072,6 +1095,8 @@ struct Compiler
 
         // the inline frame will be used to compile return statements as well as to reject recursive inlining attempts
         inlineFrames.push_back({func, oldLocals, target, targetCount});
+
+        compileFunctionArgDefaults(func);
 
         // this pass tracks which calls are builtins and can be compiled more efficiently
         analyzeBuiltins(inlineBuiltins, globals, variables, options, func->body, names);

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -34,6 +34,7 @@ LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAGVARIABLE(LuauCompileStringInterpTargetTop)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAGVARIABLE(LuauEmitCallFeedback)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 namespace Luau
 {
@@ -439,7 +440,8 @@ struct Compiler
 
         argCount = localStack.size();
 
-        compileFunctionArgDefaults(func);
+        if (FFlag::LuauDefaultArguments)
+            compileFunctionArgDefaults(func);
 
         AstStatBlock* stat = func->body;
 
@@ -981,12 +983,15 @@ struct Compiler
         args.reserve(func->args.size);
 
         bool hasArgDefaults = false;
-        for (AstExpr* defaultValue : func->argsDefaults)
+        if (FFlag::LuauDefaultArguments)
         {
-            if (defaultValue)
+            for (AstExpr* defaultValue : func->argsDefaults)
             {
-                hasArgDefaults = true;
-                break;
+                if (defaultValue)
+                {
+                    hasArgDefaults = true;
+                    break;
+                }
             }
         }
 
@@ -1096,7 +1101,8 @@ struct Compiler
         // the inline frame will be used to compile return statements as well as to reject recursive inlining attempts
         inlineFrames.push_back({func, oldLocals, target, targetCount});
 
-        compileFunctionArgDefaults(func);
+        if (FFlag::LuauDefaultArguments)
+            compileFunctionArgDefaults(func);
 
         // this pass tracks which calls are builtins and can be compiled more efficiently
         analyzeBuiltins(inlineBuiltins, globals, variables, options, func->body, names);

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -412,6 +412,29 @@ struct Compiler
 
         argCount = localStack.size();
 
+        for (size_t i = 0; i < func->argsDefaults.size; ++i)
+        {
+            AstExpr* defaultValue = func->argsDefaults.data[i];
+            if (defaultValue == nullptr)
+                continue;
+
+            // Guaranteed to have been allocated due to pushLocal above
+            Local* l = locals.find(func->args.data[i]);
+
+            size_t jumpLabel = bytecode.emitLabel();
+            // Compare our register to nil
+            bytecode.emitAD(LOP_JUMPXEQKNIL, l->reg, 0);
+            // Invert condition
+            bytecode.emitAux(0 | 0x80000000);
+
+            { // Make a new scope to save on registers
+                RegScope rs_expr(this);
+                compileExpr(defaultValue, l->reg, true);
+            }
+
+            patchJump(defaultValue, jumpLabel, bytecode.emitLabel());
+        }
+
         AstStatBlock* stat = func->body;
 
         bool terminatesEarly = false;
@@ -5100,6 +5123,7 @@ void compileOrThrow(BytecodeBuilder& bytecode, const ParseResult& parseResult, A
         /* genericPacks= */ AstArray<AstGenericTypePack*>(),
         /* self= */ nullptr,
         AstArray<AstLocal*>(),
+        AstArray<AstExpr*>(),
         /* vararg= */ true,
         /* varargLocation= */ Luau::Location(),
         root,

--- a/tests/AstJsonEncoder.test.cpp
+++ b/tests/AstJsonEncoder.test.cpp
@@ -13,12 +13,14 @@ using namespace Luau;
 
 
 LUAU_FASTFLAG(LuauDisallowExternClassInTypeDefinitions)
+LUAU_FASTFLAG(DebugLuauDefaultArguments)
 
 struct JsonEncoderFixture
 {
     Allocator allocator;
     AstNameTable names{allocator};
     ScopedFastFlag sff{FFlag::LuauDisallowExternClassInTypeDefinitions, true};
+    ScopedFastFlag sffDefaultArguments{FFlag::DebugLuauDefaultArguments, true};
 
     ParseResult parse(std::string_view src)
     {
@@ -109,7 +111,8 @@ TEST_CASE("encode_AstStatBlock")
 
     CHECK(
         toJson(&block) ==
-        (R"({"type":"AstStatBlock","location":"0,0 - 0,0","hasEnd":true,"body":[{"type":"AstStatLocal","location":"0,0 - 0,0","vars":[{"luauType":null,"name":"a_local","isConst":false,"type":"AstLocal","location":"0,0 - 0,0"}],"values":[]}]})")
+        (R"({"type":"AstStatBlock","location":"0,0 - 0,0","hasEnd":true,"body":[{"type":"AstStatLocal","location":"0,0 - 0,0","vars":[{"luauType":null,"name":"a_local","isConst":false,"type":"AstLocal","location":"0,0 - 0,0"}],"values":[]}]})"
+        )
     );
 }
 
@@ -128,7 +131,8 @@ TEST_CASE_FIXTURE(JsonEncoderFixture, "encode_tables")
 
     CHECK(
         json ==
-        (R"({"type":"AstStatBlock","location":"0,0 - 6,4","hasEnd":true,"body":[{"type":"AstStatLocal","location":"1,8 - 5,9","vars":[{"luauType":{"type":"AstTypeTable","location":"1,17 - 3,9","props":[{"name":"foo","type":"AstTableProp","location":"2,12 - 2,15","propType":{"type":"AstTypeReference","location":"2,17 - 2,23","name":"number","nameLocation":"2,17 - 2,23","parameters":[]}}],"indexer":null},"name":"x","isConst":false,"type":"AstLocal","location":"1,14 - 1,15"}],"values":[{"type":"AstExprTable","location":"3,12 - 5,9","items":[{"type":"AstExprTableItem","kind":"record","key":{"type":"AstExprConstantString","location":"4,12 - 4,15","value":"foo"},"value":{"type":"AstExprConstantNumber","location":"4,18 - 4,21","value":123}}]}]}]})")
+        (R"({"type":"AstStatBlock","location":"0,0 - 6,4","hasEnd":true,"body":[{"type":"AstStatLocal","location":"1,8 - 5,9","vars":[{"luauType":{"type":"AstTypeTable","location":"1,17 - 3,9","props":[{"name":"foo","type":"AstTableProp","location":"2,12 - 2,15","propType":{"type":"AstTypeReference","location":"2,17 - 2,23","name":"number","nameLocation":"2,17 - 2,23","parameters":[]}}],"indexer":null},"name":"x","isConst":false,"type":"AstLocal","location":"1,14 - 1,15"}],"values":[{"type":"AstExprTable","location":"3,12 - 5,9","items":[{"type":"AstExprTableItem","kind":"record","key":{"type":"AstExprConstantString","location":"4,12 - 4,15","value":"foo"},"value":{"type":"AstExprConstantNumber","location":"4,18 - 4,21","value":123}}]}]}]})"
+        )
     );
 }
 

--- a/tests/AstJsonEncoder.test.cpp
+++ b/tests/AstJsonEncoder.test.cpp
@@ -13,14 +13,14 @@ using namespace Luau;
 
 
 LUAU_FASTFLAG(LuauDisallowExternClassInTypeDefinitions)
-LUAU_FASTFLAG(DebugLuauDefaultArguments)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 struct JsonEncoderFixture
 {
     Allocator allocator;
     AstNameTable names{allocator};
     ScopedFastFlag sff{FFlag::LuauDisallowExternClassInTypeDefinitions, true};
-    ScopedFastFlag sffDefaultArguments{FFlag::DebugLuauDefaultArguments, true};
+    ScopedFastFlag sffDefaultArguments{FFlag::LuauDefaultArguments, true};
 
     ParseResult parse(std::string_view src)
     {

--- a/tests/AstJsonEncoder.test.cpp
+++ b/tests/AstJsonEncoder.test.cpp
@@ -253,7 +253,7 @@ TEST_CASE_FIXTURE(JsonEncoderFixture, "encode_AstExprFunction")
     AstExpr* expr = expectParseExpr("function (a) return a end");
 
     std::string_view expected =
-        R"({"type":"AstExprFunction","location":"0,4 - 0,29","attributes":[],"generics":[],"genericPacks":[],"args":[{"luauType":null,"name":"a","isConst":false,"type":"AstLocal","location":"0,14 - 0,15"}],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"0,16 - 0,26","hasEnd":true,"body":[{"type":"AstStatReturn","location":"0,17 - 0,25","list":[{"type":"AstExprLocal","location":"0,24 - 0,25","local":{"luauType":null,"name":"a","isConst":false,"type":"AstLocal","location":"0,14 - 0,15"}}]}]},"functionDepth":1,"debugname":""})";
+        R"({"type":"AstExprFunction","location":"0,4 - 0,29","attributes":[],"generics":[],"genericPacks":[],"args":[{"luauType":null,"name":"a","isConst":false,"type":"AstLocal","location":"0,14 - 0,15"}],"argsDefaults":[null],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"0,16 - 0,26","hasEnd":true,"body":[{"type":"AstStatReturn","location":"0,17 - 0,25","list":[{"type":"AstExprLocal","location":"0,24 - 0,25","local":{"luauType":null,"name":"a","isConst":false,"type":"AstLocal","location":"0,14 - 0,15"}}]}]},"functionDepth":1,"debugname":""})";
 
     CHECK(toJson(expr) == expected);
 }
@@ -401,7 +401,7 @@ TEST_CASE_FIXTURE(JsonEncoderFixture, "encode_AstStatLocalFunction")
     AstStat* statement = expectParseStatement("local function a(b) return end");
 
     std::string_view expected =
-        R"({"type":"AstStatLocalFunction","location":"0,0 - 0,30","name":{"luauType":null,"name":"a","isConst":false,"type":"AstLocal","location":"0,15 - 0,16"},"func":{"type":"AstExprFunction","location":"0,0 - 0,30","attributes":[],"generics":[],"genericPacks":[],"args":[{"luauType":null,"name":"b","isConst":false,"type":"AstLocal","location":"0,17 - 0,18"}],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"0,19 - 0,27","hasEnd":true,"body":[{"type":"AstStatReturn","location":"0,20 - 0,26","list":[]}]},"functionDepth":1,"debugname":"a"}})";
+        R"({"type":"AstStatLocalFunction","location":"0,0 - 0,30","name":{"luauType":null,"name":"a","isConst":false,"type":"AstLocal","location":"0,15 - 0,16"},"func":{"type":"AstExprFunction","location":"0,0 - 0,30","attributes":[],"generics":[],"genericPacks":[],"args":[{"luauType":null,"name":"b","isConst":false,"type":"AstLocal","location":"0,17 - 0,18"}],"argsDefaults":[null],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"0,19 - 0,27","hasEnd":true,"body":[{"type":"AstStatReturn","location":"0,20 - 0,26","list":[]}]},"functionDepth":1,"debugname":"a"}})";
 
     CHECK(toJson(statement) == expected);
 }
@@ -440,7 +440,7 @@ TEST_CASE_FIXTURE(JsonEncoderFixture, "encode_AstAttr")
     AstStat* expr = expectParseStatement("@checked function a(b) return c end");
 
     std::string_view expected =
-        R"({"type":"AstStatFunction","location":"0,0 - 0,35","name":{"type":"AstExprGlobal","location":"0,18 - 0,19","global":"a"},"func":{"type":"AstExprFunction","location":"0,0 - 0,35","attributes":[{"type":"AstAttr","location":"0,0 - 0,8","name":"checked"}],"generics":[],"genericPacks":[],"args":[{"luauType":null,"name":"b","isConst":false,"type":"AstLocal","location":"0,20 - 0,21"}],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"0,22 - 0,32","hasEnd":true,"body":[{"type":"AstStatReturn","location":"0,23 - 0,31","list":[{"type":"AstExprGlobal","location":"0,30 - 0,31","global":"c"}]}]},"functionDepth":1,"debugname":"a"}})";
+        R"({"type":"AstStatFunction","location":"0,0 - 0,35","name":{"type":"AstExprGlobal","location":"0,18 - 0,19","global":"a"},"func":{"type":"AstExprFunction","location":"0,0 - 0,35","attributes":[{"type":"AstAttr","location":"0,0 - 0,8","name":"checked"}],"generics":[],"genericPacks":[],"args":[{"luauType":null,"name":"b","isConst":false,"type":"AstLocal","location":"0,20 - 0,21"}],"argsDefaults":[null],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"0,22 - 0,32","hasEnd":true,"body":[{"type":"AstStatReturn","location":"0,23 - 0,31","list":[{"type":"AstExprGlobal","location":"0,30 - 0,31","global":"c"}]}]},"functionDepth":1,"debugname":"a"}})";
 
     CHECK(toJson(expr) == expected);
 }
@@ -547,7 +547,7 @@ TEST_CASE_FIXTURE(JsonEncoderFixture, "encode_AstGenericType")
     CHECK(1 == root->body.size);
 
     std::string_view expected =
-        R"({"type":"AstStatAssign","location":"1,8 - 2,11","vars":[{"type":"AstExprGlobal","location":"1,8 - 1,9","global":"a"}],"values":[{"type":"AstExprFunction","location":"1,12 - 2,11","attributes":[],"generics":[{"type":"AstGenericType","name":"b"},{"type":"AstGenericType","name":"c"}],"genericPacks":[],"args":[],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"1,28 - 2,8","hasEnd":true,"body":[]},"functionDepth":1,"debugname":""}]})";
+        R"({"type":"AstStatAssign","location":"1,8 - 2,11","vars":[{"type":"AstExprGlobal","location":"1,8 - 1,9","global":"a"}],"values":[{"type":"AstExprFunction","location":"1,12 - 2,11","attributes":[],"generics":[{"type":"AstGenericType","name":"b"},{"type":"AstGenericType","name":"c"}],"genericPacks":[],"args":[],"argsDefaults":[],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"1,28 - 2,8","hasEnd":true,"body":[]},"functionDepth":1,"debugname":""}]})";
 
     CHECK(toJson(root->body.data[0]) == expected);
 }
@@ -576,7 +576,7 @@ TEST_CASE_FIXTURE(JsonEncoderFixture, "encode_AstGenericTypePack")
     CHECK(1 == root->body.size);
 
     std::string_view expected =
-        R"({"type":"AstStatAssign","location":"1,8 - 2,11","vars":[{"type":"AstExprGlobal","location":"1,8 - 1,9","global":"a"}],"values":[{"type":"AstExprFunction","location":"1,12 - 2,11","attributes":[],"generics":[],"genericPacks":[{"type":"AstGenericTypePack","name":"b"},{"type":"AstGenericTypePack","name":"c"}],"args":[],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"1,34 - 2,8","hasEnd":true,"body":[]},"functionDepth":1,"debugname":""}]})";
+        R"({"type":"AstStatAssign","location":"1,8 - 2,11","vars":[{"type":"AstExprGlobal","location":"1,8 - 1,9","global":"a"}],"values":[{"type":"AstExprFunction","location":"1,12 - 2,11","attributes":[],"generics":[],"genericPacks":[{"type":"AstGenericTypePack","name":"b"},{"type":"AstGenericTypePack","name":"c"}],"args":[],"argsDefaults":[],"vararg":false,"varargLocation":"0,0 - 0,0","body":{"type":"AstStatBlock","location":"1,34 - 2,8","hasEnd":true,"body":[]},"functionDepth":1,"debugname":""}]})";
 
     CHECK(toJson(root->body.data[0]) == expected);
 }

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -12038,4 +12038,66 @@ RETURN R3 1
     );
 }
 
+TEST_CASE("DefaultArguments")
+{
+    // Assigning constants as default arguments
+    CHECK_EQ(
+        "\n" + compileFunction0(R"(
+function foo(x = 5) return x end
+)"),
+        R"(
+JUMPXEQKNIL R0 L0 NOT
+LOADK R0 K0 [5]
+L0: RETURN R0 1
+)"
+    );
+
+    // Accessing upvalue locals
+    CHECK_EQ(
+        "\n" + compileFunction0(R"(
+local CONST = 10
+function foo(x = CONST) return x end
+)"),
+        R"(
+JUMPXEQKNIL R0 L0 NOT
+GETUPVAL R0 0
+L0: RETURN R0 1
+)"
+    );
+
+    // More complicated statement that can't be folded
+    CHECK_EQ(
+        "\n" + compileFunction0(R"(
+local CONST1 = 10
+local CONST2 = 20
+function foo(x = math.max(CONST1, CONST2)) return x end
+)"),
+        R"(
+JUMPXEQKNIL R0 L0 NOT
+GETUPVAL R1 0
+GETUPVAL R2 1
+FASTCALL2 18 R1 R2 L0
+GETIMPORT R0 2 [math.max]
+CALL R0 2 1
+L0: RETURN R0 1
+)"
+    );
+
+    // Multiple default arguments
+    CHECK_EQ(
+        "\n" + compileFunction0(R"(
+function foo(x = 5, y, z = 15) return x + y + z end
+)"),
+        R"(
+JUMPXEQKNIL R0 L0 NOT
+LOADK R0 K0 [5]
+L0: JUMPXEQKNIL R2 L1 NOT
+LOADK R2 K1 [15]
+L1: ADD R4 R0 R1
+ADD R3 R4 R2
+RETURN R3 1
+)"
+    );
+}
+
 TEST_SUITE_END();

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -30,6 +30,7 @@ LUAU_FASTFLAG(LuauCompileStringInterpTargetTop)
 LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(LuauEmitCallFeedback)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 using namespace Luau;
 
@@ -12040,6 +12041,8 @@ RETURN R3 1
 
 TEST_CASE("DefaultArguments")
 {
+    ScopedFastFlag sff{FFlag::LuauDefaultArguments, true};
+
     // Assigning constants as default arguments
     CHECK_EQ(
         "\n" + compileFunction0(R"(

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -71,6 +71,7 @@ LUAU_FASTFLAG(LuauUdataMetatablePinned)
 LUAU_DYNAMIC_FASTFLAG(LuauGcTableStepFix)
 LUAU_FASTFLAG(LuauCodegenFixTwoResA64Builtin)
 LUAU_FASTFLAG(LuauMathRoundNegZero)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 #ifndef LUAU_CONFORMANCE_SOURCE_DIR
 // Walks up from the current directory looking for the Client folder,
@@ -4762,7 +4763,9 @@ TEST_CASE("CodegenRandomizeFunctionalCorrectness")
 
 TEST_CASE("DefaultArguments")
 {
-    runConformance("defaultarg.lua");
+    ScopedFastFlag sff{FFlag::LuauDefaultArguments, true};
+
+    runConformance("defaultarg.luau");
 }
 
 TEST_SUITE_END();

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -4760,4 +4760,9 @@ TEST_CASE("CodegenRandomizeFunctionalCorrectness")
     CHECK(lua_tonumber(L, -1) == 42.0);
 }
 
+TEST_CASE("DefaultArguments")
+{
+    runConformance("defaultarg.lua");
+}
+
 TEST_SUITE_END();

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -23,7 +23,7 @@ LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
 LUAU_FASTFLAG(LuauTrackPrefixLocal)
-LUAU_FASTFLAG(DebugLuauDefaultArguments)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 LUAU_FASTFLAG(LuauNoDuplicateBinaryPrefix)
 
@@ -2157,14 +2157,14 @@ TEST_CASE_FIXTURE(Fixture, "default_arguments_are_gated")
 {
     matchParseError("local function foo(x = 1) end", "Expected ')' (to close '(' at column 19), got '='");
 
-    ScopedFastFlag sff{FFlag::DebugLuauDefaultArguments, true};
+    ScopedFastFlag sff{FFlag::LuauDefaultArguments, true};
 
     parse("local function foo(x = 1) end");
 }
 
 TEST_CASE_FIXTURE(Fixture, "default_arguments_are_not_allowed_in_declarations")
 {
-    ScopedFastFlag sff{FFlag::DebugLuauDefaultArguments, true};
+    ScopedFastFlag sff{FFlag::LuauDefaultArguments, true};
 
     matchParseError("declare function foo(x: number = 1)", "Expected ')' (to close '(' at column 21), got '='");
     matchParseError(

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -23,6 +23,7 @@ LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
 LUAU_FASTFLAG(LuauTrackPrefixLocal)
+LUAU_FASTFLAG(DebugLuauDefaultArguments)
 
 LUAU_FASTFLAG(LuauNoDuplicateBinaryPrefix)
 
@@ -2150,6 +2151,30 @@ TEST_CASE_FIXTURE(Fixture, "parse_declarations")
 
     matchParseError("declare function foo(x)", "All declaration parameters must be annotated");
     matchParseError("declare foo", "Expected ':' when parsing global variable declaration, got <eof>");
+}
+
+TEST_CASE_FIXTURE(Fixture, "default_arguments_are_gated")
+{
+    matchParseError("local function foo(x = 1) end", "Expected ')' (to close '(' at column 19), got '='");
+
+    ScopedFastFlag sff{FFlag::DebugLuauDefaultArguments, true};
+
+    parse("local function foo(x = 1) end");
+}
+
+TEST_CASE_FIXTURE(Fixture, "default_arguments_are_not_allowed_in_declarations")
+{
+    ScopedFastFlag sff{FFlag::DebugLuauDefaultArguments, true};
+
+    matchParseError("declare function foo(x: number = 1)", "Expected ')' (to close '(' at column 21), got '='");
+    matchParseError(
+        R"(
+            declare extern type Foo with
+                function bar(self, x: number = 1)
+            end
+        )",
+        "Expected ')' (to close '(' at line 3), got '='"
+    );
 }
 
 TEST_CASE_FIXTURE(Fixture, "parse_global_declaration_called_class")
@@ -5860,7 +5885,7 @@ export local answer = 42
         R"(
 export class Player
     public health: number
-    
+
     function setHealth(self, health: number)
         self.health = health
         return self

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -2173,7 +2173,7 @@ TEST_CASE_FIXTURE(Fixture, "default_arguments_are_not_allowed_in_declarations")
                 function bar(self, x: number = 1)
             end
         )",
-        "Expected ')' (to close '(' at line 3), got '='"
+        "Expected ')' (to close '(' at column 29), got '='"
     );
 }
 

--- a/tests/PrettyPrinter.test.cpp
+++ b/tests/PrettyPrinter.test.cpp
@@ -13,6 +13,7 @@ LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauTableEntriesDontNeedToMatchIndent)
 LUAU_FASTFLAG(LuauCstAttr)
+LUAU_FASTFLAG(DebugLuauDefaultArguments)
 
 using namespace Luau;
 
@@ -902,6 +903,8 @@ TEST_CASE("roundtrip_generic_types")
 
 TEST_CASE("roundtrip_function_arg_defaults")
 {
+    ScopedFastFlag sff{FFlag::DebugLuauDefaultArguments, true};
+
     const std::string code = R"(
         local function foo(a:string=1)
         end

--- a/tests/PrettyPrinter.test.cpp
+++ b/tests/PrettyPrinter.test.cpp
@@ -13,7 +13,7 @@ LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauTableEntriesDontNeedToMatchIndent)
 LUAU_FASTFLAG(LuauCstAttr)
-LUAU_FASTFLAG(DebugLuauDefaultArguments)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 using namespace Luau;
 
@@ -903,7 +903,7 @@ TEST_CASE("roundtrip_generic_types")
 
 TEST_CASE("roundtrip_function_arg_defaults")
 {
-    ScopedFastFlag sff{FFlag::DebugLuauDefaultArguments, true};
+    ScopedFastFlag sff{FFlag::LuauDefaultArguments, true};
 
     const std::string code = R"(
         local function foo(a:string=1)

--- a/tests/PrettyPrinter.test.cpp
+++ b/tests/PrettyPrinter.test.cpp
@@ -900,6 +900,23 @@ TEST_CASE("roundtrip_generic_types")
     CHECK_EQ(code, prettyPrintWithTypes(*parseResult.root));
 }
 
+TEST_CASE("roundtrip_function_arg_defaults")
+{
+    const std::string code = R"(
+        local function foo(a:string=1)
+        end
+    )";
+    auto allocator = Allocator{};
+    auto names = AstNameTable{allocator};
+
+    ParseOptions options;
+
+    ParseResult parseResult = Parser::parse(code.data(), code.size(), names, allocator, options);
+    REQUIRE(parseResult.errors.empty());
+
+    CHECK_EQ(code, prettyPrintWithTypes(*parseResult.root));
+}
+
 TEST_CASE_FIXTURE(Fixture, "attach_types")
 {
     const std::string code = R"(

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -120,14 +120,15 @@ TEST_CASE_FIXTURE(Fixture, "cannot_hoist_interior_defns_into_signature")
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(
-        result.errors[0] == TypeError{
-                                Location{{1, 28}, {1, 29}},
-                                getMainSourceModule()->name,
-                                UnknownSymbol{
-                                    "T",
-                                    UnknownSymbol::Context::Type,
-                                }
-                            }
+        result.errors[0] ==
+        TypeError{
+            Location{{1, 28}, {1, 29}},
+            getMainSourceModule()->name,
+            UnknownSymbol{
+                "T",
+                UnknownSymbol::Context::Type,
+            }
+        }
     );
 }
 
@@ -4366,6 +4367,32 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "pass_generic_function_to_pcall")
     LUAU_CHECK_NO_ERRORS(result);
 
     CHECK("number" == toString(requireType("result")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "default_argument_infers_parameter_type")
+{
+    ScopedFastFlag sff{FFlag::DebugLuauForceOldSolver, false};
+
+    CheckResult result = check(R"(
+        local function foo(bar = 1)
+            return bar
+        end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("(number?) -> number", toString(requireType("foo")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "default_argument_is_checked_against_parameter_annotation")
+{
+    ScopedFastFlag sff{FFlag::DebugLuauForceOldSolver, false};
+
+    CheckResult result = check(R"(
+        local function foo(bar: string = 1)
+        end
+    )");
+
+    CHECK(!result.errors.empty());
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -25,7 +25,7 @@ LUAU_FASTFLAG(LuauBidirectionalInferenceVariadics)
 LUAU_FASTFLAG(LuauBidirectionalInferenceBetterLambdaHandling)
 LUAU_FASTFLAG(LuauHigherOrderGenericInference)
 LUAU_FASTFLAG(LuauCollapseDirectBoundCycles)
-LUAU_FASTFLAG(DebugLuauDefaultArguments)
+LUAU_FASTFLAG(LuauDefaultArguments)
 
 TEST_SUITE_BEGIN("TypeInferFunctions");
 
@@ -121,15 +121,14 @@ TEST_CASE_FIXTURE(Fixture, "cannot_hoist_interior_defns_into_signature")
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(
-        result.errors[0] ==
-        TypeError{
-            Location{{1, 28}, {1, 29}},
-            getMainSourceModule()->name,
-            UnknownSymbol{
-                "T",
-                UnknownSymbol::Context::Type,
-            }
-        }
+        result.errors[0] == TypeError{
+                                Location{{1, 28}, {1, 29}},
+                                getMainSourceModule()->name,
+                                UnknownSymbol{
+                                    "T",
+                                    UnknownSymbol::Context::Type,
+                                }
+                            }
     );
 }
 
@@ -4374,7 +4373,7 @@ TEST_CASE_FIXTURE(Fixture, "default_argument_infers_parameter_type")
 {
     ScopedFastFlag sffs[] = {
         {FFlag::DebugLuauForceOldSolver, false},
-        {FFlag::DebugLuauDefaultArguments, true},
+        {FFlag::LuauDefaultArguments, true},
     };
 
     CheckResult result = check(R"(
@@ -4391,7 +4390,7 @@ TEST_CASE_FIXTURE(Fixture, "default_argument_is_checked_against_parameter_annota
 {
     ScopedFastFlag sffs[] = {
         {FFlag::DebugLuauForceOldSolver, false},
-        {FFlag::DebugLuauDefaultArguments, true},
+        {FFlag::LuauDefaultArguments, true},
     };
 
     CheckResult result = check(R"(

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -25,6 +25,7 @@ LUAU_FASTFLAG(LuauBidirectionalInferenceVariadics)
 LUAU_FASTFLAG(LuauBidirectionalInferenceBetterLambdaHandling)
 LUAU_FASTFLAG(LuauHigherOrderGenericInference)
 LUAU_FASTFLAG(LuauCollapseDirectBoundCycles)
+LUAU_FASTFLAG(DebugLuauDefaultArguments)
 
 TEST_SUITE_BEGIN("TypeInferFunctions");
 
@@ -4371,7 +4372,10 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "pass_generic_function_to_pcall")
 
 TEST_CASE_FIXTURE(Fixture, "default_argument_infers_parameter_type")
 {
-    ScopedFastFlag sff{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::DebugLuauDefaultArguments, true},
+    };
 
     CheckResult result = check(R"(
         local function foo(bar = 1)
@@ -4385,7 +4389,10 @@ TEST_CASE_FIXTURE(Fixture, "default_argument_infers_parameter_type")
 
 TEST_CASE_FIXTURE(Fixture, "default_argument_is_checked_against_parameter_annotation")
 {
-    ScopedFastFlag sff{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::DebugLuauDefaultArguments, true},
+    };
 
     CheckResult result = check(R"(
         local function foo(bar: string = 1)

--- a/tests/conformance/defaultarg.luau
+++ b/tests/conformance/defaultarg.luau
@@ -1,0 +1,89 @@
+
+-- This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+print("testing function argument default values")
+
+local function test_local_access()
+    local CONSTANT_VALUE = 1
+    -- Ensure we're accessing upvalues correctly
+    function foo(x = CONSTANT_VALUE) end
+end
+test_local_access()
+
+local function test_nil_omit()
+    -- It should be possible to specify y without needing to specify x
+    function foo(x = 1, y = 2)
+        return x, y
+    end
+
+    local x, y = foo(nil, 3)
+    assert(x == 1)
+    assert(y == 3)
+end
+test_nil_omit()
+
+local function test_not_singleton()
+    -- The default argument should be evaluated every time the function is called
+    function foo(x = {a = 0})
+        x.a += 1
+        return x.a
+    end
+    assert(foo() == foo())
+end
+test_not_singleton()
+
+local function test_complex_self()
+    local Foo = {}
+
+    function Foo.inc(self = { count = 0, inc = Foo.inc }, val = 1)
+      self.count += val
+      return self
+    end
+
+    local foo = { count = 0, inc = Foo.inc }
+    assert(foo:inc().count == 1)
+    assert(foo:inc().count == 2)
+    assert(foo:inc(2).count == 4)
+
+    assert(Foo.inc().count == 1)
+    assert(Foo.inc().count == 1)
+    assert(Foo.inc(foo).count == 5)
+    assert(Foo.inc(foo, 2).count == 7)
+end
+test_complex_self()
+
+local function test_metatable()
+    local Foo = {}
+
+    function Foo.inc(
+        self = setmetatable({
+                count = 0,
+            }, {
+                __index = Foo,
+            }
+        ),
+        val = 1
+    )
+        self.count += val
+        return self
+    end
+
+    local foo = Foo.inc()
+    assert(foo.count == 1)
+    assert(foo:inc().count == 2)
+    assert(foo:inc(2).count == 4)
+end
+test_metatable()
+
+local function test_index_default()
+    local mt = {}
+    function mt.__index(self, key = "count")
+        return rawget(self, key)
+    end
+
+    local foo = setmetatable({ count = 5 }, mt)
+    -- This "shouldn't" work but our default argument made it work
+    assert(foo[nil] == 5)
+end
+test_index_default()
+
+return "OK"


### PR DESCRIPTION
Implements default arguments as specified in https://github.com/luau-lang/rfcs/pull/91, with the exception that `foo(a, b=a)` is legal.

Default arguments cannot be specified in declaration syntax because they aren't meaningful there. Class fields and member methods are currently untouched due to the in-flux nature of classes at the moment.

Support should in theory be present for both the old and new solver. Default arguments are currently implemented as `T?` at the call site, rather than as multiple function overloads.

Feature is gated behind the `LuauDefaultArguments` fflag.