### PR TITLE
Workaround for exported class being `nil` within class scope for methods

### DIFF
--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -1622,7 +1622,7 @@ struct Compiler
         checkConstant(classConst, decl->location);
         bytecode.patchAux(auxOffset, classConst);
 
-        if (FFlag::LuauExportedClassIsNilWorkaround)
+        if (FFlag::LuauExportedClassIsNilWorkaround && decl->exported)
         {
             // ERIN: Temporary workaround for bug where exported class is `nil` within the class scope (methods etc)
             // We assign it to the export table immediately after the declaration, whereas normally that would only

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -35,6 +35,7 @@ LUAU_FASTFLAGVARIABLE(LuauCompileStringInterpTargetTop)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAGVARIABLE(LuauEmitCallFeedback)
 LUAU_FASTFLAG(LuauDefaultArguments)
+LUAU_FASTFLAGVARIABLE(LuauExportedClassIsNilWorkaround)
 
 namespace Luau
 {
@@ -1620,6 +1621,22 @@ struct Compiler
         int32_t classConst = bytecode.addClassShape(std::move(shape));
         checkConstant(classConst, decl->location);
         bytecode.patchAux(auxOffset, classConst);
+
+        if (FFlag::LuauExportedClassIsNilWorkaround)
+        {
+            // ERIN: Temporary workaround for bug where exported class is `nil` within the class scope (methods etc)
+            // We assign it to the export table immediately after the declaration, whereas normally that would only
+            // happen at the end of the module before the implicit `return` statement.
+            LUAU_ASSERT(currentFunction);
+
+            LUAU_ASSERT(locals.contains(&exportTableLocal));
+            int8_t tableReg = getLocalReg(&exportTableLocal);
+            LUAU_ASSERT(tableReg >= 0);
+
+            bytecode.emitAD(LOP_LOADK, dest, classConst);
+            bytecode.emitABC(LOP_SETTABLEKS, dest, tableReg, uint8_t(BytecodeBuilder::getStringHash(sref(decl->name->name))));
+            bytecode.emitAux(shape.className);
+        }
     }
 
     LuauOpcode getUnaryOp(AstExprUnary::Op op)

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -66,6 +66,8 @@ LUAU_FASTFLAG(LuauCodegenFixBufferLenCheck)
 LUAU_FASTFLAG(LuauYieldIter2)
 LUAU_FASTFLAG(LuauCustomYieldablePcalls)
 LUAU_FASTFLAG(DebugLuauUserDefinedClassesRuntime)
+LUAU_FASTFLAG(LuauExportValueSyntax)
+LUAU_FASTFLAG(LuauExportedClassIsNilWorkaround)
 LUAU_FASTFLAG(LuauAutoStack)
 LUAU_FASTFLAG(LuauUdataMetatablePinned)
 LUAU_DYNAMIC_FASTFLAG(LuauGcTableStepFix)
@@ -4234,6 +4236,18 @@ TEST_CASE("Classes")
     };
 
     runConformance("classes.luau");
+}
+
+TEST_CASE("ExportedClasses")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauUserDefinedClasses, true},
+        {FFlag::DebugLuauUserDefinedClassesRuntime, true},
+        {FFlag::LuauExportValueSyntax, true},
+        {FFlag::LuauExportedClassIsNilWorkaround, true},
+    };
+
+    runConformance("exportclasses.luau");
 }
 
 [[nodiscard]] static std::string makeHugeFunctionSource()

--- a/tests/conformance/exportclasses.luau
+++ b/tests/conformance/exportclasses.luau
@@ -1,0 +1,35 @@
+--!nocheck
+
+-- `export` statements force the module's implicit return to be the (frozen) export table, which
+-- conflicts with an explicit top-level `return`. So the exported class under test lives in its own
+-- chunk, loaded and run via loadstring, while this outer chunk stays export-free and can `return 'OK'`.
+-- Since the inner chunk can't `return` its result either (same export/return conflict), it stashes
+-- the result in a global instead.
+local source = [[
+    export class Cat
+        public name: string
+        public age: number
+        function new(name: string)
+            return Cat {
+                name = name,
+                age = 0
+            }
+        end
+    end
+
+    catTestResult = Cat.new("Cat will disappear")
+]]
+
+local chunk, compileErr = loadstring(source)
+assert(chunk, `failed to compile export class chunk: {tostring(compileErr)}`)
+
+local ok, err = pcall(chunk)
+
+assert(ok, `expected Cat.new (called from within Cat's own class scope) to succeed, got error: {tostring(err)}`)
+
+local result = catTestResult
+assert(typeof(result) == "object", `expected typeof(result) == "object", got {typeof(result)}`)
+
+print("ok: exported class is not nil within its own scope")
+
+return 'OK'


### PR DESCRIPTION
Flagged behind `LuauExportedClassIsNilWorkaround`. Fixes https://github.com/luau-lang/luau/issues/2570

This fix is ugly because most of the time it just redundantly re-assigns the class to the export table. Oh well.