### PR TITLE
Support generic parameters on extern types

### DIFF
--- a/Analysis/include/Luau/ApplyTypeFunction.h
+++ b/Analysis/include/Luau/ApplyTypeFunction.h
@@ -19,6 +19,18 @@ struct ApplyTypeFunction : Substitution
 
     // Never set under deferred constraint resolution.
     bool encounteredForwardedType;
+
+    // When instantiating a nominal type with generic parameters (see LuauGenericNominals),
+    // this is the TypeId of the template ExternType currently being expanded, which is
+    // `tf->type` in ConstraintSolver::tryDispatch(TypeAliasExpansionConstraint). ExternTypes
+    // are normally opaque leaves to this substitution, so their contents are left alone and
+    // their nominal identity is preserved. The template being instantiated right now is the
+    // one exception: its contents need to be visited so its generics can actually be replaced
+    // with the supplied arguments. Every other ExternType this substitution runs into elsewhere
+    // in the type graph (an unrelated class reached through some field, a non-generic
+    // superclass, etc.) stays fully opaque, same as before.
+    TypeId genericNominalRoot = nullptr;
+
     std::unordered_map<TypeId, TypeId> typeArguments;
     std::unordered_map<TypePackId, TypePackId> typePackArguments;
     bool ignoreChildren(TypeId ty) override;

--- a/Analysis/include/Luau/Constraint.h
+++ b/Analysis/include/Luau/Constraint.h
@@ -106,6 +106,11 @@ struct FunctionCallConstraint
     // When we dispatch this constraint, we update the key at this map to record
     // the overload that we selected.
     DenseHashMap<const AstNode*, TypeId>* astOverloadResolvedTypes = nullptr;
+
+    // The type this call is expected to produce, if any (e.g. from a `local x: T = f(...)`
+    // annotation or a `return` in a function with a declared return type). Used to resolve
+    // generics that argument matching alone leaves unconstrained.
+    std::optional<TypeId> expectedType;
 };
 
 // function_check fn argsPack

--- a/Analysis/include/Luau/ConstraintGenerator.h
+++ b/Analysis/include/Luau/ConstraintGenerator.h
@@ -323,13 +323,14 @@ private:
         bool generalize = true
     );
 
-    InferencePack checkPack(const ScopePtr& scope, AstExprCall* call);
+    InferencePack checkPack(const ScopePtr& scope, AstExprCall* call, std::optional<TypeId> expectedType = std::nullopt);
     InferencePack checkExprCall(
         const ScopePtr& scope,
         AstExprCall* call,
         TypeId fnType,
         Checkpoint funcBeginCheckpoint,
-        Checkpoint funcEndCheckpoint
+        Checkpoint funcEndCheckpoint,
+        std::optional<TypeId> expectedType = std::nullopt
     );
 
     /**

--- a/Analysis/include/Luau/ConstraintGenerator.h
+++ b/Analysis/include/Luau/ConstraintGenerator.h
@@ -116,6 +116,10 @@ struct ConstraintGenerator
     // The private scope of type aliases for which the type parameters belong to.
     DenseHashMap<const AstStatTypeAlias*, ScopePtr> astTypeAliasDefiningScopes{nullptr};
 
+    // The private scope of an extern type declaration, used to resolve type references
+    // (e.g. a generic method's own type parameters) within its body. See LuauExternTypeUseDefinitionScope.
+    DenseHashMap<const AstStatDeclareExternType*, ScopePtr> astExternTypeDefiningScopes{nullptr};
+
     NotNull<const DataFlowGraph> dfg;
     RefinementArena refinementArena;
 

--- a/Analysis/include/Luau/Instantiation.h
+++ b/Analysis/include/Luau/Instantiation.h
@@ -139,9 +139,17 @@ struct GenericTypeFinder : TypeOnceVisitor
         return false;
     }
 
+    // Set by the caller (see LuauGenericNominals) to allow traversing into one specific
+    // ExternType -- the one this GenericTypeFinder is being run on -- while every other
+    // ExternType reached during that traversal remains opaque, same as before.
+    TypeId root = nullptr;
+
     bool visit(TypeId ty, const Luau::ExternType&) override
     {
         // During function instantiation, extern types are not traversed even if they have generics
+        if (ty == root)
+            return true;
+
         return false;
     }
 };

--- a/Analysis/include/Luau/Type.h
+++ b/Analysis/include/Luau/Type.h
@@ -589,6 +589,16 @@ struct ExternType
      */
     std::optional<NominalRelation> relation;
 
+    // True if this ExternType is a generic nominal type instantiation (see LuauGenericNominals)
+    // that still contains an unresolved generic somewhere inside it. Substitution visitors use
+    // this to decide whether to descend into it looking for further generics to replace.
+    bool hasUnresolvedGenerics = false;
+
+    // The type arguments this ExternType was instantiated with (see LuauGenericNominals), used
+    // to display instantiations like `Box<number>` when stringifying the type.
+    std::vector<TypeId> instantiatedTypeParams;
+    std::vector<TypePackId> instantiatedTypePackParams;
+
     ExternType(
         Name name,
         Props props,

--- a/Analysis/include/Luau/VisitType.h
+++ b/Analysis/include/Luau/VisitType.h
@@ -11,6 +11,7 @@
 
 LUAU_FASTINT(LuauVisitRecursionLimit)
 LUAU_FASTFLAG(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier)
+LUAU_FASTFLAG(LuauGenericNominals)
 
 namespace Luau
 {
@@ -351,6 +352,15 @@ struct GenericTypeVisitor
                 {
                     traverse(etv->indexer->indexType);
                     traverse(etv->indexer->indexResultType);
+                }
+
+                if (FFlag::LuauGenericNominals)
+                {
+                    for (TypeId itp : etv->instantiatedTypeParams)
+                        traverse(itp);
+
+                    for (TypePackId itp : etv->instantiatedTypePackParams)
+                        traverse(itp);
                 }
             }
         }

--- a/Analysis/src/ApplyTypeFunction.cpp
+++ b/Analysis/src/ApplyTypeFunction.cpp
@@ -2,6 +2,10 @@
 
 #include "Luau/ApplyTypeFunction.h"
 
+#include "Luau/Common.h"
+
+LUAU_FASTFLAG(LuauGenericNominals)
+
 namespace Luau
 {
 
@@ -32,7 +36,19 @@ bool ApplyTypeFunction::ignoreChildren(TypeId ty)
     if (get<GenericType>(ty))
         return true;
     else if (get<ExternType>(ty))
+    {
+        if (FFlag::LuauGenericNominals)
+        {
+            // replaceChildren() re-checks ignoreChildren on the freshly cloned type, so the
+            // root check must also match the clone produced for genericNominalRoot, not just
+            // the template itself.
+            TypeId* clonedRoot = genericNominalRoot ? newTypes.find(genericNominalRoot) : nullptr;
+            if (ty == genericNominalRoot || (clonedRoot && ty == *clonedRoot) || get<ExternType>(ty)->hasUnresolvedGenerics)
+                return false;
+        }
+
         return true;
+    }
     else
         return false;
 }

--- a/Analysis/src/Clone.cpp
+++ b/Analysis/src/Clone.cpp
@@ -12,6 +12,7 @@
 #include "Luau/VisitType.h"
 
 LUAU_FASTFLAG(LuauSolverV2)
+LUAU_FASTFLAG(LuauGenericNominals)
 
 // For each `Luau::clone` call, we will clone only up to N amount of types _and_ packs, as controlled by this limit.
 LUAU_FASTINTVARIABLE(LuauTypeCloneIterationLimit, 100'000)
@@ -178,6 +179,7 @@ public:
 
         (*types)[ty] = target;
         queue.push_back(target);
+
         return target;
     }
 
@@ -372,6 +374,15 @@ private:
                 },
                 *t->relation
             );
+        }
+
+        if (FFlag::LuauGenericNominals)
+        {
+            for (TypeId& itp : t->instantiatedTypeParams)
+                itp = shallowClone(itp);
+
+            for (TypePackId& itp : t->instantiatedTypePackParams)
+                itp = shallowClone(itp);
         }
     }
 

--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -3027,7 +3027,7 @@ Inference ConstraintGenerator::check(const ScopePtr& scope, AstExpr* expr, std::
     else if (expr->is<AstExprVarargs>())
         result = flattenPack(scope, expr->location, checkPack(scope, expr));
     else if (auto call = expr->as<AstExprCall>())
-        result = flattenPack(scope, expr->location, checkPack(scope, call, expectedType)); // TODO: needs predicates too
+        result = flattenPack(scope, expr->location, checkPack(scope, call, expectedType));
     else if (auto a = expr->as<AstExprFunction>())
         result = check(scope, a, expectedType, generalize);
     else if (auto indexName = expr->as<AstExprIndexName>())

--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -52,6 +52,7 @@ LUAU_FASTFLAGVARIABLE(LuauDeprecatedAttributeOnAnonymousFunctions)
 LUAU_FASTFLAGVARIABLE(DebugLuauCFG)
 LUAU_FASTFLAG(LuauDefaultArguments)
 LUAU_FASTFLAGVARIABLE(LuauExternTypeUseDefinitionScope)
+LUAU_FASTFLAG(LuauGenericNominals)
 
 namespace Luau
 {
@@ -1035,12 +1036,23 @@ void ConstraintGenerator::prototypeTypeDefinitions(const ScopePtr& scope, AstSta
 
             ScopePtr defnScope = childScope(classDeclaration, scope);
 
-            if (FFlag::LuauExternTypeUseDefinitionScope)
+            if (FFlag::LuauExternTypeUseDefinitionScope || FFlag::LuauGenericNominals)
                 astExternTypeDefiningScopes[classDeclaration] = defnScope;
 
             TypeId initialType = arena->addType(BlockedType{});
             TypeFun initialFun{initialType};
             initialFun.definitionLocation = classDeclaration->location;
+
+            if (FFlag::LuauGenericNominals)
+            {
+                for (const auto& [name, gen] : createGenerics(defnScope, classDeclaration->generics, /* useCache */ true, /* addTypes */ false))
+                    initialFun.typeParams.push_back(gen);
+
+                for (const auto& [name, genPack] :
+                     createGenericPacks(defnScope, classDeclaration->genericPacks, /* useCache */ true, /* addTypes */ false))
+                    initialFun.typePackParams.push_back(genPack);
+            }
+
             scope->exportedTypeBindings[classDeclaration->name.value] = std::move(initialFun);
 
             if (FFlag::LuauTidyTypePrototyping)
@@ -2226,8 +2238,26 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatDeclareExte
             return ControlFlow::None;
         }
 
-        // We don't have generic extern typeArguments, so this assertion _should_ never be hit.
-        LUAU_ASSERT(lookupType->typeParams.size() == 0 && lookupType->typePackParams.size() == 0);
+        if (FFlag::LuauGenericNominals && (lookupType->typeParams.size() != 0 || lookupType->typePackParams.size() != 0))
+        {
+            // `extends Base<T>` isn't supported yet -- the parser doesn't even accept type
+            // arguments after a supertype name -- so the only way to reach this is a generic
+            // supertype referenced without any arguments, which we don't allow.
+            reportError(
+                declaredExternType->location,
+                GenericError{format("Generic extern type '%s' cannot be used as a superclass without type arguments", superName.c_str())}
+            );
+
+            emplaceType<BoundType>(asMutable(bindingIt->second.type), builtinTypes->errorType);
+
+            return ControlFlow::None;
+        }
+        else if (!FFlag::LuauGenericNominals)
+        {
+            // We don't have generic extern typeArguments, so this assertion _should_ never be hit.
+            LUAU_ASSERT(lookupType->typeParams.size() == 0 && lookupType->typePackParams.size() == 0);
+        }
+
         superTy = follow(lookupType->type);
 
         if (!get<ExternType>(follow(*superTy)))
@@ -2266,10 +2296,43 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatDeclareExte
     // method's own type parameters - nest under it instead of becoming sibling scopes that
     // TypeChecker2's location-based scope lookup can never find. See LuauExternTypeUseDefinitionScope.
     ScopePtr bodyScope = scope;
-    if (FFlag::LuauExternTypeUseDefinitionScope)
+    if (FFlag::LuauExternTypeUseDefinitionScope || FFlag::LuauGenericNominals)
     {
         if (ScopePtr* defnScopePtr = astExternTypeDefiningScopes.find(declaredExternType))
             bodyScope = *defnScopePtr;
+    }
+
+    // Bind the extern type's own generics (e.g. the `T` in `declare extern type Box<T> with ... end`)
+    // into its definition scope, so that references to `T` inside the indexer, properties, and
+    // methods resolve to these type-level generics rather than erroring or (worse) accidentally
+    // resolving to an unrelated same-named generic elsewhere in the file.
+    if (FFlag::LuauGenericNominals)
+    {
+        LUAU_ASSERT(declaredExternType->generics.size == bindingIt->second.typeParams.size());
+        for (size_t i = 0; i < declaredExternType->generics.size; ++i)
+        {
+            AstGenericType* astTy = declaredExternType->generics.data[i];
+            const GenericTypeDefinition& param = bindingIt->second.typeParams[i];
+            bodyScope->privateTypeBindings[astTy->name.value] = TypeFun{param.ty};
+        }
+
+        LUAU_ASSERT(declaredExternType->genericPacks.size == bindingIt->second.typePackParams.size());
+        for (size_t i = 0; i < declaredExternType->genericPacks.size; ++i)
+        {
+            AstGenericTypePack* astPack = declaredExternType->genericPacks.data[i];
+            const GenericTypePackDefinition& param = bindingIt->second.typePackParams[i];
+            bodyScope->privateTypePackBindings[astPack->name.value] = param.tp;
+        }
+
+        // Methods implicitly take `self`, typed below as the bare extern type (externTy). For a
+        // generic extern type, `self` needs to be `Box<T>` (applied to the type's own generics),
+        // not the bare, unparameterized `Box` -- otherwise calling a method on `Box<number>`
+        // fails to match against `self`, since neither side would look like the other nominally.
+        for (const GenericTypeDefinition& param : bindingIt->second.typeParams)
+            etv->instantiatedTypeParams.push_back(param.ty);
+        for (const GenericTypePackDefinition& param : bindingIt->second.typePackParams)
+            etv->instantiatedTypePackParams.push_back(param.tp);
+        etv->hasUnresolvedGenerics = !etv->instantiatedTypeParams.empty() || !etv->instantiatedTypePackParams.empty();
     }
 
     if (declaredExternType->indexer)
@@ -2283,6 +2346,10 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatDeclareExte
             // I don't think extern types can *be* generic, but if they
             // have an indexer over those generics, the polarity is
             // mixed.
+            //
+            // mluau fork note (deviaze): extern types can now be generic, behind
+            // LuauGenericNominals. When enabled, this indexer's index/result types
+            // may reference the extern type's own generics, bound into bodyScope above.
             etv->indexer = TableIndexer{
                 resolveType(
                     bodyScope,
@@ -2608,7 +2675,12 @@ InferencePack ConstraintGenerator::checkPack(
     InferencePack result;
 
     if (AstExprCall* call = expr->as<AstExprCall>())
-        result = checkPack(scope, call);
+    {
+        std::optional<TypeId> expectedType;
+        if (FFlag::LuauGenericNominals && !expectedTypes.empty())
+            expectedType = expectedTypes[0];
+        result = checkPack(scope, call, expectedType);
+    }
     else if (expr->is<AstExprVarargs>())
     {
         if (scope->varargPack)
@@ -2630,7 +2702,7 @@ InferencePack ConstraintGenerator::checkPack(
     return result;
 }
 
-InferencePack ConstraintGenerator::checkPack(const ScopePtr& scope, AstExprCall* call)
+InferencePack ConstraintGenerator::checkPack(const ScopePtr& scope, AstExprCall* call, std::optional<TypeId> expectedType)
 {
     Checkpoint funcBeginCheckpoint = checkpoint(this);
 
@@ -2642,7 +2714,7 @@ InferencePack ConstraintGenerator::checkPack(const ScopePtr& scope, AstExprCall*
 
     Checkpoint funcEndCheckpoint = checkpoint(this);
 
-    return checkExprCall(scope, call, fnType, funcBeginCheckpoint, funcEndCheckpoint);
+    return checkExprCall(scope, call, fnType, funcBeginCheckpoint, funcEndCheckpoint, expectedType);
 }
 
 InferencePack ConstraintGenerator::checkExprCall(
@@ -2650,7 +2722,8 @@ InferencePack ConstraintGenerator::checkExprCall(
     AstExprCall* call,
     TypeId fnType,
     Checkpoint funcBeginCheckpoint,
-    Checkpoint funcEndCheckpoint
+    Checkpoint funcEndCheckpoint,
+    std::optional<TypeId> expectedType
 )
 {
     std::vector<AstExpr*> exprArgs;
@@ -2892,6 +2965,7 @@ InferencePack ConstraintGenerator::checkExprCall(
             std::move(explicitTypeIds),
             std::move(explicitTypePackIds),
             &module->astOverloadResolvedTypes,
+            FFlag::LuauGenericNominals ? expectedType : std::nullopt,
         }
     );
 
@@ -2953,7 +3027,7 @@ Inference ConstraintGenerator::check(const ScopePtr& scope, AstExpr* expr, std::
     else if (expr->is<AstExprVarargs>())
         result = flattenPack(scope, expr->location, checkPack(scope, expr));
     else if (auto call = expr->as<AstExprCall>())
-        result = flattenPack(scope, expr->location, checkPack(scope, call)); // TODO: needs predicates too
+        result = flattenPack(scope, expr->location, checkPack(scope, call, expectedType)); // TODO: needs predicates too
     else if (auto a = expr->as<AstExprFunction>())
         result = check(scope, a, expectedType, generalize);
     else if (auto indexName = expr->as<AstExprIndexName>())
@@ -3552,7 +3626,9 @@ std::tuple<TypeId, TypeId, RefinementId> ConstraintGenerator::checkBinary(
         }
         else if (!typeguard->isTypeof)
             discriminantTy = builtinTypes->neverType;
-        else if (auto typeFun = globalScope->lookupType(typeguard->type); typeFun && typeFun->typeParams.empty() && typeFun->typePackParams.empty())
+        else if (auto typeFun = globalScope->lookupType(typeguard->type);
+                 typeFun && (FFlag::LuauGenericNominals ? get<ExternType>(follow(typeFun->type)) != nullptr
+                                                         : (typeFun->typeParams.empty() && typeFun->typePackParams.empty())))
         {
             TypeId ty = follow(typeFun->type);
 
@@ -4655,7 +4731,9 @@ std::vector<std::pair<Name, GenericTypeDefinition>> ConstraintGenerator::createG
 
         if (auto it = scope->parent->typeAliasTypeParameters.find(generic->name.value);
             useCache && it != scope->parent->typeAliasTypeParameters.end())
+        {
             genericTy = it->second;
+        }
         else
         {
             genericTy = arena->addType(GenericType{scope.get(), generic->name.value, Polarity::None});

--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -51,6 +51,7 @@ LUAU_FLAGVERSION(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier, 2)
 LUAU_FASTFLAGVARIABLE(LuauDeprecatedAttributeOnAnonymousFunctions)
 LUAU_FASTFLAGVARIABLE(DebugLuauCFG)
 LUAU_FASTFLAG(LuauDefaultArguments)
+LUAU_FASTFLAGVARIABLE(LuauExternTypeUseDefinitionScope)
 
 namespace Luau
 {
@@ -1033,6 +1034,9 @@ void ConstraintGenerator::prototypeTypeDefinitions(const ScopePtr& scope, AstSta
             }
 
             ScopePtr defnScope = childScope(classDeclaration, scope);
+
+            if (FFlag::LuauExternTypeUseDefinitionScope)
+                astExternTypeDefiningScopes[classDeclaration] = defnScope;
 
             TypeId initialType = arena->addType(BlockedType{});
             TypeFun initialFun{initialType};
@@ -2257,6 +2261,17 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatDeclareExte
     TypeId classBindTy = bindingIt->second.type;
     emplaceType<BoundType>(asMutable(classBindTy), externTy);
 
+    // Indexer and property types are resolved against the extern type's own definition scope
+    // (rather than the enclosing scope) so that per-property type references - e.g. a generic
+    // method's own type parameters - nest under it instead of becoming sibling scopes that
+    // TypeChecker2's location-based scope lookup can never find. See LuauExternTypeUseDefinitionScope.
+    ScopePtr bodyScope = scope;
+    if (FFlag::LuauExternTypeUseDefinitionScope)
+    {
+        if (ScopePtr* defnScopePtr = astExternTypeDefiningScopes.find(declaredExternType))
+            bodyScope = *defnScopePtr;
+    }
+
     if (declaredExternType->indexer)
     {
         if (recursionCount >= DFInt::LuauConstraintGeneratorRecursionLimit)
@@ -2270,14 +2285,14 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatDeclareExte
             // mixed.
             etv->indexer = TableIndexer{
                 resolveType(
-                    scope,
+                    bodyScope,
                     declaredExternType->indexer->indexType,
                     /* inTypeArguments */ false,
                     /* replaceErrorWithFresh */ false,
                     /* initialPolarity */ Polarity::Mixed
                 ),
                 resolveType(
-                    scope,
+                    bodyScope,
                     declaredExternType->indexer->resultType,
                     /* inTypeArguments */ false,
                     /* replaceErrorWithFresh */ false,
@@ -2290,8 +2305,9 @@ ControlFlow ConstraintGenerator::visit(const ScopePtr& scope, AstStatDeclareExte
     for (const AstDeclaredExternTypeProperty& externProp : declaredExternType->props)
     {
         Name propName(externProp.name.value);
-        TypeId propTy =
-            resolveType(scope, externProp.ty, /* inTypeArguments */ false, /* replaceErrorWithFresh */ false, /* initialPolarity */ Polarity::Mixed);
+        TypeId propTy = resolveType(
+            bodyScope, externProp.ty, /* inTypeArguments */ false, /* replaceErrorWithFresh */ false, /* initialPolarity */ Polarity::Mixed
+        );
 
         bool assignToMetatable = isMetamethod(propName);
 

--- a/Analysis/src/ConstraintSolver.cpp
+++ b/Analysis/src/ConstraintSolver.cpp
@@ -44,6 +44,7 @@ LUAU_FASTFLAGVARIABLE(DebugLuauLogSolver)
 LUAU_FASTFLAGVARIABLE(DebugLuauLogBindings)
 LUAU_FASTFLAGVARIABLE(LuauFixPropReadsOnMetatableTypes)
 LUAU_FASTFLAGVARIABLE(LuauAlsoInstantiateInferredArguments)
+LUAU_FASTFLAG(LuauGenericNominals)
 LUAU_FLAGVERSION(LuauAlsoInstantiateInferredArguments, 2)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAGVARIABLE(LuauRemoveConstraintSolverEmplace)
@@ -287,6 +288,35 @@ size_t HashInstantiationSignature::operator()(const InstantiationSignature& sign
     return hash;
 }
 
+// Like GenericTypeFinder, but also treats an unresolved PendingExpansionType (e.g. a nested
+// generic nominal instantiation like `Box<Box<T>>` where the inner `Box<T>` hasn't been expanded
+// yet) as something that still needs to be found and resolved. See ExternType::hasUnresolvedGenerics.
+struct UnresolvedGenericNominalFinder : GenericTypeFinder
+{
+    using GenericTypeFinder::visit;
+
+    bool visit(TypeId ty, const PendingExpansionType&) override
+    {
+        found = true;
+        return false;
+    }
+
+    // A method with its own generics (e.g. `To` in `function map<To>(self): Option<To>`) doesn't
+    // mean the enclosing extern type still has an unresolved reference to its own generic -- but
+    // the base class's check treats it as "found" regardless, which would permanently mark every
+    // instantiation of the enclosing type as unresolved. Skip such methods instead.
+    bool visit(TypeId ty, const Luau::FunctionType& ftv) override
+    {
+        if (ftv.hasNoFreeOrGenericTypes)
+            return false;
+
+        if (!ftv.generics.empty() || !ftv.genericPacks.empty())
+            return false;
+
+        return !found;
+    }
+};
+
 struct InstantiationQueuer : IterativeTypeVisitor
 {
     ConstraintSolver* solver;
@@ -323,6 +353,9 @@ struct InstantiationQueuer : IterativeTypeVisitor
 
     bool visit(TypeId ty, const ExternType& etv) override
     {
+        if (FFlag::LuauGenericNominals && etv.hasUnresolvedGenerics)
+            return true;
+
         return false;
     }
 };
@@ -401,6 +434,22 @@ struct InfiniteTypeFinder : IterativeTypeVisitor
         }
 
         return false;
+    }
+
+    bool visit(TypeId ty, const FunctionType& ftv) override
+    {
+        if (foundInfiniteType)
+            return false;
+
+        // A method that declares its own generics (e.g. `function map<To>(self): Option<To>`
+        // on `extern type Option<T>`) is not eagerly expanded the way a table type alias body
+        // is: `To` is bound fresh at each call site, not at Option's own definition. Without
+        // this carve-out, this reference to `Option<To>` looks identical to the genuinely
+        // infinite `type Foo<T> = { x: Foo<SomeOtherType> }` case, since `To != T`.
+        if (FFlag::LuauGenericNominals && (!ftv.generics.empty() || !ftv.genericPacks.empty()))
+            return false;
+
+        return true;
     }
 };
 
@@ -1376,6 +1425,8 @@ bool ConstraintSolver::tryDispatch(const TypeAliasExpansionConstraint& c, NotNul
     // e.g. `<T...>(T...) -> T...` instantiated with `any` for `T...` becomes
     // `<any>(any) -> any`, where none of these things are _generics_.
     ApplyTypeFunction applyTypeFunction{arena};
+    if (FFlag::LuauGenericNominals)
+        applyTypeFunction.genericNominalRoot = follow(tf->type);
     for (size_t i = 0; i < typeArguments.size(); ++i)
     {
         applyTypeFunction.typeArguments[tf->typeParams[i].ty] = typeArguments[i];
@@ -1393,13 +1444,45 @@ bool ConstraintSolver::tryDispatch(const TypeAliasExpansionConstraint& c, NotNul
 
     if (!maybeInstantiated.has_value())
     {
-        // TODO (CLI-56761): Report an error.
+        // TODO (CLI-56761): Report an error unconditionally, not just under this flag.
+        if (FFlag::LuauGenericNominals)
+            reportError(CodeTooComplex{}, constraint->location);
         bindResult(builtinTypes->errorType);
         return true;
     }
 
     TypeId instantiated = *maybeInstantiated;
     TypeId target = follow(instantiated);
+
+    // Record whether this freshly-instantiated generic nominal type still contains an
+    // unresolved generic anywhere inside it. See ExternType::hasUnresolvedGenerics.
+    if (FFlag::LuauGenericNominals && get<ExternType>(follow(tf->type)))
+    {
+        // If none of the type arguments were actually used in the template body, substitution
+        // hands back tf->type unchanged (no clone). We still want a distinct object per
+        // instantiation so that e.g. `type SpecificResult = Result<SpecificType>` can display
+        // `Result<SpecificType>` rather than losing that argument -- so clone it here, the same
+        // way the TableType case below does for the analogous "generic saturatedTypeArguments go
+        // unused" situation.
+        if (target == follow(tf->type) && (!tf->typeParams.empty() || !tf->typePackParams.empty()))
+        {
+            CloneState cloneState{builtinTypes};
+            instantiated = shallowClone(target, *arena.get(), cloneState, true);
+            target = follow(instantiated);
+        }
+
+        if (ExternType* targetExternType = getMutable<ExternType>(target); targetExternType && !target->persistent)
+        {
+            // Must run before the marker traversal below, since it inspects instantiatedTypeParams.
+            targetExternType->instantiatedTypeParams = typeArguments;
+            targetExternType->instantiatedTypePackParams = packArguments;
+
+            UnresolvedGenericNominalFinder marker;
+            marker.root = target;
+            marker.traverse(target);
+            targetExternType->hasUnresolvedGenerics = marker.found;
+        }
+    }
 
     // The application is not recursive, so we need to queue up application of
     // any child type function instantiations within the result in order for it
@@ -1480,6 +1563,67 @@ void ConstraintSolver::fillInDiscriminantTypes(NotNull<const Constraint> constra
         // We also need to unconditionally unblock these types, otherwise
         // you end up with funky looking "Blocked on *no-refine*."
         unblock(*ty, constraint->location);
+    }
+}
+
+// Argument matching alone often leaves a generic nominal type's type argument totally
+// unconstrained (e.g. `E` in `function ok<T, E>(value: T): Result<T, E>` -- nothing about the
+// call site's arguments says anything about `E`). Left alone, that generic defaults to
+// `unknown` (see Instantiation2.cpp's `pickBound`), which then fails a subtype check against
+// whatever the call site actually expected. If the call has a known expected type shaped like
+// the same generic nominal type, and a given generic is otherwise completely unconstrained,
+// prefer binding it directly to the expected type's corresponding argument instead of
+// defaulting it -- this is the return-type-directed half of bidirectional inference that
+// already exists for lambda arguments and table literals, extended to generic nominal types.
+static void patchUnconstrainedGenericsFromExpectedType(TypeId overloadFn, TypeId expectedType, DenseHashMap<TypeId, TypeId>& genericSubstitutions)
+{
+    const FunctionType* ftv = get<FunctionType>(overloadFn);
+    if (!ftv)
+        return;
+
+    TypePackId retPack = follow(ftv->retTypes);
+    auto it = begin(retPack);
+    if (it == end(retPack))
+        return;
+
+    const ExternType* retEt = get<ExternType>(follow(*it));
+    const ExternType* expectedEt = get<ExternType>(follow(expectedType));
+    if (!retEt || !expectedEt)
+        return;
+
+    if (retEt->name != expectedEt->name || retEt->definitionModuleName != expectedEt->definitionModuleName ||
+        retEt->definitionLocation != expectedEt->definitionLocation)
+        return;
+
+    if (retEt->instantiatedTypeParams.size() != expectedEt->instantiatedTypeParams.size())
+        return;
+
+    for (size_t i = 0; i < retEt->instantiatedTypeParams.size(); ++i)
+    {
+        TypeId param = follow(retEt->instantiatedTypeParams[i]);
+        if (!get<GenericType>(param))
+            continue;
+
+        TypeId* subst = genericSubstitutions.find(param);
+        if (!subst)
+            continue;
+
+        // The instantiation machinery (Instantiation2_DEPRECATED::clean in particular) asserts
+        // that a generic's substitution entry is always a FreeType, so we pin its bounds rather
+        // than replacing the entry outright -- that keeps the invariant intact while still
+        // making `pickBound` (Instantiation2.cpp) resolve to the expected type.
+        FreeType* ft = getMutable<FreeType>(follow(*subst));
+        if (!ft)
+            continue;
+
+        // Only patch generics that argument matching left completely unconstrained; if
+        // arguments already pinned a lower bound, trust that over the expected type.
+        if (!is<NeverType>(follow(ft->lowerBound)) || !is<UnknownType>(follow(ft->upperBound)))
+            continue;
+
+        TypeId expectedArg = expectedEt->instantiatedTypeParams[i];
+        ft->lowerBound = expectedArg;
+        ft->upperBound = expectedArg;
     }
 }
 
@@ -1644,6 +1788,9 @@ bool ConstraintSolver::tryDispatch(const FunctionCallConstraint& c, NotNull<cons
         trackInteriorFreeType(constraint->scope, freeTy);
     for (TypePackId freeTp : u2.newFreshTypePacks)
         trackInteriorFreeTypePack(constraint->scope, freeTp);
+
+    if (FFlag::LuauGenericNominals && c.expectedType)
+        patchUnconstrainedGenericsFromExpectedType(overloadToUse, follow(*c.expectedType), u2.genericSubstitutions);
 
     if (!u2.genericSubstitutions.empty() || !u2.genericPackSubstitutions.empty())
     {
@@ -3036,7 +3183,11 @@ TypeId ConstraintSolver::instantiateFunctionType(
 
     auto result = r.substitute(clonedFunctionTypeId);
     if (!result)
+    {
+        if (FFlag::LuauGenericNominals)
+            reportError(CodeTooComplex{}, location);
         return builtinTypes->errorType;
+    }
     return *result;
 }
 

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -6,6 +6,7 @@ LUAU_FASTFLAG(LuauIntegerType2)
 LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauUdtfTypeIsSubtypeOf)
+LUAU_FASTFLAG(LuauBufferIsFrozen)
 
 namespace Luau
 {
@@ -242,7 +243,7 @@ declare utf8: {
 
 )BUILTIN_SRC";
 
-static constexpr const char* kBuiltinDefinitionBufferSrc = R"BUILTIN_SRC(
+static constexpr const char* kBuiltinDefinitionBufferSrcCore = R"BUILTIN_SRC(
 --- Buffer API
 declare buffer: {
     create: @checked (size: number) -> buffer,
@@ -271,41 +272,18 @@ declare buffer: {
     writestring: @checked (b: buffer, offset: number, value: string, count: number?) -> (),
     readbits: @checked (b: buffer, bitOffset: number, bitCount: number) -> number,
     writebits: @checked (b: buffer, bitOffset: number, bitCount: number, value: number) -> (),
-    readinteger: @checked (b: buffer, offset: number) -> integer,
-    writeinteger: @checked (b: buffer, offset: number, value: integer) -> (),
-}
-
 )BUILTIN_SRC";
 
-static constexpr const char* kBuiltinDefinitionBufferSrc_NOINTEGER = R"BUILTIN_SRC(
---- Buffer API
-declare buffer: {
-    create: @checked (size: number) -> buffer,
-    fromstring: @checked (str: string) -> buffer,
-    tostring: @checked (b: buffer) -> string,
-    len: @checked (b: buffer) -> number,
-    copy: @checked (target: buffer, targetOffset: number, source: buffer, sourceOffset: number?, count: number?) -> (),
-    fill: @checked (b: buffer, offset: number, value: number, count: number?) -> (),
-    readi8: @checked (b: buffer, offset: number) -> number,
-    readu8: @checked (b: buffer, offset: number) -> number,
-    readi16: @checked (b: buffer, offset: number) -> number,
-    readu16: @checked (b: buffer, offset: number) -> number,
-    readi32: @checked (b: buffer, offset: number) -> number,
-    readu32: @checked (b: buffer, offset: number) -> number,
-    readf32: @checked (b: buffer, offset: number) -> number,
-    readf64: @checked (b: buffer, offset: number) -> number,
-    writei8: @checked (b: buffer, offset: number, value: number) -> (),
-    writeu8: @checked (b: buffer, offset: number, value: number) -> (),
-    writei16: @checked (b: buffer, offset: number, value: number) -> (),
-    writeu16: @checked (b: buffer, offset: number, value: number) -> (),
-    writei32: @checked (b: buffer, offset: number, value: number) -> (),
-    writeu32: @checked (b: buffer, offset: number, value: number) -> (),
-    writef32: @checked (b: buffer, offset: number, value: number) -> (),
-    writef64: @checked (b: buffer, offset: number, value: number) -> (),
-    readstring: @checked (b: buffer, offset: number, count: number) -> string,
-    writestring: @checked (b: buffer, offset: number, value: string, count: number?) -> (),
-    readbits: @checked (b: buffer, bitOffset: number, bitCount: number) -> number,
-    writebits: @checked (b: buffer, bitOffset: number, bitCount: number, value: number) -> ()
+static constexpr const char* kBuiltinDefinitionBufferSrcInteger = R"BUILTIN_SRC(
+    readinteger: @checked (b: buffer, offset: number) -> integer,
+    writeinteger: @checked (b: buffer, offset: number, value: integer) -> (),
+)BUILTIN_SRC";
+
+static constexpr const char* kBuiltinDefinitionBufferSrcIsFrozen = R"BUILTIN_SRC(
+    isfrozen: @checked (b: buffer) -> boolean,
+)BUILTIN_SRC";
+
+static constexpr const char* kBuiltinDefinitionBufferSrcClose = R"BUILTIN_SRC(
 }
 
 )BUILTIN_SRC";
@@ -407,10 +385,12 @@ std::string getBuiltinDefinitionSource()
     result += kBuiltinDefinitionTableSrc;
     result += kBuiltinDefinitionDebugSrc;
     result += kBuiltinDefinitionUtf8Src;
+    result += kBuiltinDefinitionBufferSrcCore;
     if (FFlag::LuauIntegerType2 && FFlag::LuauIntegerLibrary)
-        result += kBuiltinDefinitionBufferSrc;
-    else
-        result += kBuiltinDefinitionBufferSrc_NOINTEGER;
+        result += kBuiltinDefinitionBufferSrcInteger;
+    if (FFlag::LuauBufferIsFrozen)
+        result += kBuiltinDefinitionBufferSrcIsFrozen;
+    result += kBuiltinDefinitionBufferSrcClose;
 
     result += kBuiltinDefinitionVectorSrc;
 

--- a/Analysis/src/Instantiation2.cpp
+++ b/Analysis/src/Instantiation2.cpp
@@ -5,6 +5,7 @@
 #include "Luau/Instantiation2.h"
 
 LUAU_FASTFLAGVARIABLE(LuauHigherOrderGenericInference)
+LUAU_FASTFLAG(LuauGenericNominals)
 
 namespace Luau
 {
@@ -49,8 +50,13 @@ TypePackId Replacer::clean(TypePackId tp)
 
 bool Replacer::ignoreChildren(TypeId ty)
 {
-    if (get<ExternType>(ty))
+    if (const ExternType* etv = get<ExternType>(ty))
+    {
+        if (FFlag::LuauGenericNominals && etv->hasUnresolvedGenerics)
+            return false;
+
         return true;
+    }
 
     if (auto ftv = get<FunctionType>(ty))
     {
@@ -91,8 +97,13 @@ bool Replacer::checkReplacementKeys() const
 
 bool Instantiation2_DEPRECATED::ignoreChildren(TypeId ty)
 {
-    if (get<ExternType>(ty))
+    if (const ExternType* etv = get<ExternType>(ty))
+    {
+        if (FFlag::LuauGenericNominals && etv->hasUnresolvedGenerics)
+            return false;
+
         return true;
+    }
 
     if (auto ftv = get<FunctionType>(ty))
     {

--- a/Analysis/src/IterativeTypeVisitor.cpp
+++ b/Analysis/src/IterativeTypeVisitor.cpp
@@ -3,6 +3,7 @@
 
 LUAU_FASTINT(LuauVisitRecursionLimit)
 LUAU_FASTFLAG(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier)
+LUAU_FASTFLAG(LuauGenericNominals)
 
 namespace Luau
 {
@@ -382,6 +383,15 @@ void IterativeTypeVisitor::process(TypeId ty)
             {
                 traverse(etv->indexer->indexType);
                 traverse(etv->indexer->indexResultType);
+            }
+
+            if (FFlag::LuauGenericNominals)
+            {
+                for (TypeId itp : etv->instantiatedTypeParams)
+                    traverse(itp);
+
+                for (TypePackId itp : etv->instantiatedTypePackParams)
+                    traverse(itp);
             }
         }
     }

--- a/Analysis/src/Module.cpp
+++ b/Analysis/src/Module.cpp
@@ -135,14 +135,19 @@ struct ClonePublicInterface : Substitution
 
     bool isDirty(TypeId ty) override
     {
-        if (ty->owningArena == module->internalTypes.get())
-            return true;
+        bool dirty = [&]
+        {
+            if (ty->owningArena == module->internalTypes.get())
+                return true;
 
-        if (const FunctionType* ftv = get<FunctionType>(ty))
-            return ftv->level.level != 0;
-        if (const TableType* ttv = get<TableType>(ty))
-            return ttv->level.level != 0;
-        return false;
+            if (const FunctionType* ftv = get<FunctionType>(ty))
+                return ftv->level.level != 0;
+            if (const TableType* ttv = get<TableType>(ty))
+                return ttv->level.level != 0;
+            return false;
+        }();
+
+        return dirty;
     }
 
     bool isDirty(TypePackId tp) override
@@ -152,10 +157,7 @@ struct ClonePublicInterface : Substitution
 
     bool ignoreChildrenVisit(TypeId ty) override
     {
-        if (ty->owningArena != module->internalTypes.get())
-            return true;
-
-        return false;
+        return ty->owningArena != module->internalTypes.get();
     }
 
     bool ignoreChildrenVisit(TypePackId tp) override

--- a/Analysis/src/Substitution.cpp
+++ b/Analysis/src/Substitution.cpp
@@ -10,6 +10,7 @@
 
 LUAU_FASTINTVARIABLE(LuauTarjanChildLimit, 10000)
 LUAU_FASTFLAG(LuauSolverV2)
+LUAU_FASTFLAG(LuauGenericNominals)
 LUAU_FASTINTVARIABLE(LuauTarjanPreallocationSize, 256)
 
 namespace Luau
@@ -132,6 +133,12 @@ static TypeId shallowClone(TypeId ty, TypeArena& dest, const TxnLog* log)
             ExternType clone{a.name, a.props, a.parent, a.metatable, a.tags, a.userData, a.definitionModuleName, a.definitionLocation, a.indexer};
             if (FFlag::DebugLuauUserDefinedClasses)
                 clone.relation = a.relation;
+            if (FFlag::LuauGenericNominals)
+            {
+                clone.hasUnresolvedGenerics = a.hasUnresolvedGenerics;
+                clone.instantiatedTypeParams = a.instantiatedTypeParams;
+                clone.instantiatedTypePackParams = a.instantiatedTypePackParams;
+            }
             return dest.addType(std::move(clone));
         }
         else if constexpr (std::is_same_v<T, NegationType>)
@@ -277,6 +284,15 @@ void Tarjan::visitChildren(TypeId ty, int index)
                 },
                 *etv->relation
             );
+        }
+
+        if (FFlag::LuauGenericNominals)
+        {
+            for (TypeId itp : etv->instantiatedTypeParams)
+                visitChild(itp);
+
+            for (TypePackId itp : etv->instantiatedTypePackParams)
+                visitChild(itp);
         }
     }
     else if (const NegationType* ntv = get<NegationType>(ty))
@@ -861,6 +877,14 @@ void Substitution::replaceChildren(TypeId ty)
         {
             etv->indexer->indexType = replace(etv->indexer->indexType);
             etv->indexer->indexResultType = replace(etv->indexer->indexResultType);
+        }
+
+        if (FFlag::LuauGenericNominals)
+        {
+            for (TypeId& itp : etv->instantiatedTypeParams)
+                itp = replace(itp);
+            for (TypePackId& itp : etv->instantiatedTypePackParams)
+                itp = replace(itp);
         }
     }
     else if (NegationType* ntv = getMutable<NegationType>(ty))

--- a/Analysis/src/ToString.cpp
+++ b/Analysis/src/ToString.cpp
@@ -20,6 +20,7 @@
 
 LUAU_FASTFLAG(LuauSolverV2)
 LUAU_FASTFLAG(LuauIntegerType2)
+LUAU_FASTFLAG(LuauGenericNominals)
 
 /*
  * Enables increasing levels of verbosity for Luau type names when stringifying.
@@ -872,6 +873,18 @@ struct TypeStringifier
     void operator()(TypeId ty, const ExternType& etv)
     {
         state.emitAndRecordSpan(etv.name, ty);
+        if (FFlag::LuauGenericNominals)
+        {
+            if (state.hasSeen(&etv))
+            {
+                state.result.cycle = true;
+                state.emit("<*CYCLE*>");
+                return;
+            }
+
+            stringify(etv.instantiatedTypeParams, etv.instantiatedTypePackParams);
+            state.unsee(&etv);
+        }
     }
 
     void operator()(TypeId, const AnyType&)

--- a/Analysis/src/Type.cpp
+++ b/Analysis/src/Type.cpp
@@ -29,6 +29,7 @@ LUAU_FASTINTVARIABLE(LuauTypeMaximumStringifierLength, 500)
 LUAU_FASTINTVARIABLE(LuauTableTypeMaximumStringifierLength, 0)
 LUAU_FASTINT(LuauTypeInferRecursionLimit)
 LUAU_FASTFLAG(LuauInstantiateInSubtyping)
+LUAU_FASTFLAG(LuauGenericNominals)
 
 namespace Luau
 {
@@ -1067,11 +1068,87 @@ const Property* lookupExternTypeProp(const ExternType* cls, const Name& name)
     return nullptr;
 }
 
+// Two independently-produced clones of the same generic nominal type instantiation (e.g. one
+// `List<string>` built while resolving a type annotation, another built for a function call's
+// return type) are not the same TypeId, but should still be treated as the same nominal type.
+// Compare by the declaration they both stem from plus their instantiation arguments instead.
+static bool isSameGenericNominalInstantiation(const ExternType* a, const ExternType* b);
+
+// A type argument to a generic nominal type can itself be a generic nominal type instantiated
+// at a different call site (e.g. `Result<string, Option<List<string>>>`'s `Option<List<string>>`
+// argument) -- those need the same nominal comparison recursively, not raw TypeId equality.
+static bool sameNominalTypeArg(TypeId a, TypeId b)
+{
+    a = follow(a);
+    b = follow(b);
+    if (a == b)
+        return true;
+
+    const ExternType* aEt = get<ExternType>(a);
+    const ExternType* bEt = get<ExternType>(b);
+    if (aEt && bEt)
+        return isSameGenericNominalInstantiation(aEt, bEt);
+
+    return false;
+}
+
+static bool isSameGenericNominalInstantiation(const ExternType* a, const ExternType* b)
+{
+    if (a->name != b->name || a->definitionModuleName != b->definitionModuleName || a->definitionLocation != b->definitionLocation)
+        return false;
+
+    if (a->instantiatedTypeParams.size() != b->instantiatedTypeParams.size())
+        return false;
+
+    if (a->instantiatedTypePackParams.size() != b->instantiatedTypePackParams.size())
+        return false;
+
+    for (size_t i = 0; i < a->instantiatedTypeParams.size(); ++i)
+    {
+        if (!sameNominalTypeArg(a->instantiatedTypeParams[i], b->instantiatedTypeParams[i]))
+            return false;
+    }
+
+    for (size_t i = 0; i < a->instantiatedTypePackParams.size(); ++i)
+    {
+        if (follow(a->instantiatedTypePackParams[i]) != follow(b->instantiatedTypePackParams[i]))
+            return false;
+    }
+
+    return true;
+}
+
+// `parent` is the bare, un-instantiated declaration of a generic nominal type (e.g. the
+// `Exception<Data>` used as the discriminant for `typeof(x) == "Exception"`, as opposed to any
+// specific instantiation like `Exception<{kind: "IoError"}>`) if every one of its "instantiated"
+// type arguments is actually just its own declared generic placeholder rather than a concrete
+// argument. See ConstraintGenerator.cpp's handling of AstStatDeclareExternType, which sets this
+// up on the canonical extern type object.
+static bool isBareGenericNominalRoot(const ExternType* cls, const ExternType* parent)
+{
+    if (cls->name != parent->name || cls->definitionModuleName != parent->definitionModuleName || cls->definitionLocation != parent->definitionLocation)
+        return false;
+
+    for (TypeId param : parent->instantiatedTypeParams)
+        if (!get<GenericType>(follow(param)))
+            return false;
+
+    for (TypePackId param : parent->instantiatedTypePackParams)
+        if (!get<GenericTypePack>(follow(param)))
+            return false;
+
+    return true;
+}
+
 bool isSubclass(const ExternType* cls, const ExternType* parent)
 {
     while (cls)
     {
         if (cls == parent)
+            return true;
+        else if (FFlag::LuauGenericNominals && isSameGenericNominalInstantiation(cls, parent))
+            return true;
+        else if (FFlag::LuauGenericNominals && isBareGenericNominalRoot(cls, parent))
             return true;
         else if (!cls->parent)
             return false;

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -3968,11 +3968,13 @@ void TypeChecker2::checkTypeInstantiation(
     {
         if (typeOrPack.type)
         {
+            visit(typeOrPack.type);
             ++typeCount;
         }
         else
         {
             LUAU_ASSERT(typeOrPack.typePack);
+            visit(typeOrPack.typePack);
             ++typePackCount;
         }
     }

--- a/Analysis/src/TypeStateMap.cpp
+++ b/Analysis/src/TypeStateMap.cpp
@@ -12,6 +12,7 @@
 
 
 LUAU_FASTINTVARIABLE(LuauMaxCFGDataflowIterations, 2);
+LUAU_FASTFLAG(LuauGenericNominals)
 
 namespace Luau::CFG
 {
@@ -188,7 +189,9 @@ TypeId TypeStateMap::getDiscriminantOf(const Refine& refine)
         // class hierarchy is irrelevant for the purposes of refinement.
         discriminantTy = builtinTypes->externType;
     }
-    else if (auto typeFun = globalScope->lookupType(name); typeFun && typeFun->typeParams.empty() && typeFun->typePackParams.empty())
+    else if (auto typeFun = globalScope->lookupType(name);
+             typeFun && (FFlag::LuauGenericNominals ? get<ExternType>(follow(typeFun->type)) != nullptr
+                                                     : (typeFun->typeParams.empty() && typeFun->typePackParams.empty())))
     {
         TypeId ty = follow(typeFun->type);
 

--- a/Analysis/src/Unifier2.cpp
+++ b/Analysis/src/Unifier2.cpp
@@ -419,7 +419,10 @@ UnifyResult Unifier2::unify_(TypeId subTy, const FunctionType* superFn)
             generic = follow(generic);
             const GenericType* gen = get<GenericType>(generic);
             if (gen)
-                genericSubstitutions[generic] = freshType(scope, gen->polarity);
+            {
+                TypeId fresh = freshType(scope, gen->polarity);
+                genericSubstitutions[generic] = fresh;
+            }
         }
 
         for (TypePackId genericPack : subFn->genericPacks)

--- a/Ast/include/Luau/Ast.h
+++ b/Ast/include/Luau/Ast.h
@@ -1153,7 +1153,9 @@ public:
         const AstName& name,
         std::optional<AstName> superName,
         const AstArray<AstDeclaredExternTypeProperty>& props,
-        AstTableIndexer* indexer = nullptr
+        AstTableIndexer* indexer = nullptr,
+        const AstArray<AstGenericType*>& generics = {},
+        const AstArray<AstGenericTypePack*>& genericPacks = {}
     );
 
     void visit(AstVisitor* visitor) override;
@@ -1163,6 +1165,9 @@ public:
 
     AstArray<AstDeclaredExternTypeProperty> props;
     AstTableIndexer* indexer;
+
+    AstArray<AstGenericType*> generics;
+    AstArray<AstGenericTypePack*> genericPacks;
 };
 
 class AstType : public AstNode

--- a/Ast/src/Ast.cpp
+++ b/Ast/src/Ast.cpp
@@ -1087,13 +1087,17 @@ AstStatDeclareExternType::AstStatDeclareExternType(
     const AstName& name,
     std::optional<AstName> superName,
     const AstArray<AstDeclaredExternTypeProperty>& props,
-    AstTableIndexer* indexer
+    AstTableIndexer* indexer,
+    const AstArray<AstGenericType*>& generics,
+    const AstArray<AstGenericTypePack*>& genericPacks
 )
     : AstStat(ClassIndex(), location)
     , name(name)
     , superName(superName)
     , props(props)
     , indexer(indexer)
+    , generics(generics)
+    , genericPacks(genericPacks)
 {
 }
 

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -35,6 +35,7 @@ LUAU_FASTFLAGVARIABLE(LuauStoreConstKeywordBegin)
 LUAU_FASTFLAGVARIABLE(LuauNoDuplicateBinaryPrefix)
 LUAU_FASTFLAGVARIABLE(LuauTrackPrefixLocal)
 LUAU_FASTFLAGVARIABLE(LuauDefaultArguments)
+LUAU_FASTFLAGVARIABLE(LuauExternTypeGenericMethods)
 
 // Clip with DebugLuauReportReturnTypeVariadicWithTypeSuffix
 bool luau_telemetry_parsed_return_type_variadic_with_type_suffix = false;
@@ -1770,13 +1771,20 @@ AstDeclaredExternTypeProperty Parser::parseDeclaredExternTypeMethod(const AstArr
 
     Name fnName = parseName("function name");
 
-    // TODO: generic method declarations CLI-39909
     AstArray<AstGenericType*> generics;
     AstArray<AstGenericTypePack*> genericPacks;
-    generics.size = 0;
-    generics.data = nullptr;
-    genericPacks.size = 0;
-    genericPacks.data = nullptr;
+
+    if (FFlag::LuauExternTypeGenericMethods)
+    {
+        std::tie(generics, genericPacks) = parseGenericTypeList(/* withDefaultValues= */ false);
+    }
+    else
+    {
+        generics.size = 0;
+        generics.data = nullptr;
+        genericPacks.size = 0;
+        genericPacks.data = nullptr;
+    }
 
     MatchLexeme matchParen = lexer.current();
     expectAndConsume('(', "function parameter list start");

--- a/Ast/src/Parser.cpp
+++ b/Ast/src/Parser.cpp
@@ -36,6 +36,7 @@ LUAU_FASTFLAGVARIABLE(LuauNoDuplicateBinaryPrefix)
 LUAU_FASTFLAGVARIABLE(LuauTrackPrefixLocal)
 LUAU_FASTFLAGVARIABLE(LuauDefaultArguments)
 LUAU_FASTFLAGVARIABLE(LuauExternTypeGenericMethods)
+LUAU_FASTFLAGVARIABLE(LuauGenericNominals)
 
 // Clip with DebugLuauReportReturnTypeVariadicWithTypeSuffix
 bool luau_telemetry_parsed_return_type_variadic_with_type_suffix = false;
@@ -1931,6 +1932,22 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
 
         Location classStart = lexer.current().location;
         Name className = parseName("type name");
+
+        AstArray<AstGenericType*> classGenerics;
+        AstArray<AstGenericTypePack*> classGenericPacks;
+
+        if (FFlag::LuauGenericNominals)
+        {
+            std::tie(classGenerics, classGenericPacks) = parseGenericTypeList(/* withDefaultValues= */ false);
+        }
+        else
+        {
+            classGenerics.size = 0;
+            classGenerics.data = nullptr;
+            classGenericPacks.size = 0;
+            classGenericPacks.data = nullptr;
+        }
+
         std::optional<AstName> superName = std::nullopt;
 
         if (AstName(lexer.current().name) == "extends")
@@ -2065,7 +2082,9 @@ AstStat* Parser::parseDeclaration(const Location& start, const AstArray<AstAttr*
         Location classEnd = lexer.current().location;
         nextLexeme(); // skip past `end`
 
-        return allocator.alloc<AstStatDeclareExternType>(Location(classStart, classEnd), className.name, superName, copy(props), indexer);
+        return allocator.alloc<AstStatDeclareExternType>(
+            Location(classStart, classEnd), className.name, superName, copy(props), indexer, classGenerics, classGenericPacks
+        );
     }
     else if (std::optional<Name> globalName = parseNameOpt("global variable name"))
     {

--- a/CodeGen/src/EmitCommonX64.h
+++ b/CodeGen/src/EmitCommonX64.h
@@ -194,7 +194,8 @@ inline void jumpIfTagIsNot(AssemblyBuilderX64& build, int ri, lua_Type tag, Labe
 inline void jumpIfFalsy(AssemblyBuilderX64& build, int ri, Label& target, Label& fallthrough)
 {
     jumpIfTagIs(build, ri, LUA_TNIL, target);             // false if nil
-    jumpIfTagIsNot(build, ri, LUA_TBOOLEAN, fallthrough); // true if not nil or boolean
+    jumpIfTagIs(build, ri, LUA_TSYMNONE, target);         // false if none (see l_isfalse)
+    jumpIfTagIsNot(build, ri, LUA_TBOOLEAN, fallthrough); // true if not nil, none, or boolean
 
     build.cmp(luauRegValueInt(ri), 0);
     build.jcc(ConditionX64::Equal, target); // true if boolean value is 'true'
@@ -203,8 +204,9 @@ inline void jumpIfFalsy(AssemblyBuilderX64& build, int ri, Label& target, Label&
 // Note: fallthrough label should be placed after this condition
 inline void jumpIfTruthy(AssemblyBuilderX64& build, int ri, Label& target, Label& fallthrough)
 {
-    jumpIfTagIs(build, ri, LUA_TNIL, fallthrough);   // false if nil
-    jumpIfTagIsNot(build, ri, LUA_TBOOLEAN, target); // true if not nil or boolean
+    jumpIfTagIs(build, ri, LUA_TNIL, fallthrough);     // false if nil
+    jumpIfTagIs(build, ri, LUA_TSYMNONE, fallthrough); // false if none (see l_isfalse)
+    jumpIfTagIsNot(build, ri, LUA_TBOOLEAN, target);   // true if not nil, none, or boolean
 
     build.cmp(luauRegValueInt(ri), 0);
     build.jcc(ConditionX64::NotEqual, target); // true if boolean value is 'true'

--- a/CodeGen/src/IrLoweringA64.cpp
+++ b/CodeGen/src/IrLoweringA64.cpp
@@ -1106,8 +1106,11 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
 
         // Check tag first
         build.umov_4s(temp, regOp(OP_A(inst)), 3);
-        build.cmp(temp, uint16_t(LUA_TBOOLEAN));
 
+        build.cmp(temp, uint16_t(LUA_TSYMNONE));
+        build.b(ConditionA64::Equal, saveRhs); // rhs if 'A' is none (see l_isfalse)
+
+        build.cmp(temp, uint16_t(LUA_TBOOLEAN));
         build.b(ConditionA64::UnsignedLess, saveRhs); // rhs if 'A' is nil
         build.b(ConditionA64::UnsignedGreater, exit); // Keep lhs if 'A' is not a boolean
 
@@ -1300,8 +1303,6 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         {
             Label notBool, exit;
 
-            // use the fact that NIL is the only value less than BOOLEAN to do two tag comparisons at once
-            CODEGEN_ASSERT(LUA_TNIL == 0 && LUA_TBOOLEAN == 1);
             build.cmp(regOp(OP_A(inst)), uint16_t(LUA_TBOOLEAN));
             build.b(ConditionA64::NotEqual, notBool);
 
@@ -1312,9 +1313,15 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
 
             build.b(exit);
 
-            // not boolean => result is true iff tag was nil
+            // not boolean => result is true iff tag was nil or symnone (the other falsy tags; see l_isfalse)
             build.setLabel(notBool);
-            build.cset(inst.regA64, ConditionA64::Less);
+            RegisterA64 tag = regOp(OP_A(inst));
+            RegisterA64 temp = regs.allocTemp(KindA64::w);
+            build.cmp(tag, uint16_t(LUA_TNIL));
+            build.cset(temp, ConditionA64::Equal);
+            build.cmp(tag, uint16_t(LUA_TSYMNONE));
+            build.cset(inst.regA64, ConditionA64::Equal);
+            build.orr(inst.regA64, inst.regA64, temp);
 
             build.setLabel(exit);
         }
@@ -1598,6 +1605,9 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         // nil => falsy
         CODEGEN_ASSERT(LUA_TNIL == 0);
         build.cbz(temp, labelOp(OP_C(inst)));
+        // none => falsy (see l_isfalse)
+        build.cmp(temp, uint16_t(LUA_TSYMNONE));
+        build.b(ConditionA64::Equal, labelOp(OP_C(inst)));
         // not boolean => truthy
         build.cmp(temp, uint16_t(LUA_TBOOLEAN));
         build.b(ConditionA64::NotEqual, labelOp(OP_B(inst)));
@@ -1614,6 +1624,9 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         // nil => falsy
         CODEGEN_ASSERT(LUA_TNIL == 0);
         build.cbz(temp, labelOp(OP_B(inst)));
+        // none => falsy (see l_isfalse)
+        build.cmp(temp, uint16_t(LUA_TSYMNONE));
+        build.b(ConditionA64::Equal, labelOp(OP_B(inst)));
         // not boolean => truthy
         build.cmp(temp, uint16_t(LUA_TBOOLEAN));
         build.b(ConditionA64::NotEqual, labelOp(OP_C(inst)));
@@ -3536,7 +3549,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         else
             CODEGEN_ASSERT(!"Unsupported instruction form");
 
-        build.ldr(inst.regA64, mem(inst.regA64, offsetof(global_State, ttname)));
+        build.ldr(inst.regA64, mem(inst.regA64, offsetof(global_State, ttypename)));
         break;
     }
     case IrCmd::GET_TYPEOF:

--- a/CodeGen/src/IrLoweringA64.cpp
+++ b/CodeGen/src/IrLoweringA64.cpp
@@ -3549,7 +3549,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         else
             CODEGEN_ASSERT(!"Unsupported instruction form");
 
-        build.ldr(inst.regA64, mem(inst.regA64, offsetof(global_State, ttypename)));
+            build.ldr(inst.regA64, mem(inst.regA64, offsetof(global_State, ttypename)));
         break;
     }
     case IrCmd::GET_TYPEOF:

--- a/CodeGen/src/IrLoweringA64.cpp
+++ b/CodeGen/src/IrLoweringA64.cpp
@@ -3549,7 +3549,7 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         else
             CODEGEN_ASSERT(!"Unsupported instruction form");
 
-            build.ldr(inst.regA64, mem(inst.regA64, offsetof(global_State, ttypename)));
+        build.ldr(inst.regA64, mem(inst.regA64, offsetof(global_State, ttypename)));
         break;
     }
     case IrCmd::GET_TYPEOF:

--- a/CodeGen/src/IrLoweringX64.cpp
+++ b/CodeGen/src/IrLoweringX64.cpp
@@ -1264,8 +1264,11 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
 
         // Check tag first
         build.vpextrd(tmp.reg, regOp(OP_A(inst)), 3);
-        build.cmp(tmp.reg, LUA_TBOOLEAN);
 
+        build.cmp(tmp.reg, LUA_TSYMNONE);
+        build.jcc(ConditionX64::Equal, saveRhs); // rhs if 'A' is none (see l_isfalse)
+
+        build.cmp(tmp.reg, LUA_TBOOLEAN);
         build.jcc(ConditionX64::Below, saveRhs); // rhs if 'A' is nil
         build.jcc(ConditionX64::Above, exit);    // Keep lhs if 'A' is not a boolean
 
@@ -1470,6 +1473,9 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         else
         {
             build.cmp(regOp(OP_A(inst)), LUA_TNIL);
+            build.jcc(ConditionX64::Equal, saveOne);
+
+            build.cmp(regOp(OP_A(inst)), LUA_TSYMNONE);
             build.jcc(ConditionX64::Equal, saveOne);
 
             build.cmp(regOp(OP_A(inst)), LUA_TBOOLEAN);
@@ -3087,9 +3093,9 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         build.mov(inst.regX64, qword[rState + offsetof(lua_State, global)]);
 
         if (OP_A(inst).kind == IrOpKind::Inst)
-            build.mov(inst.regX64, qword[inst.regX64 + qwordReg(regOp(OP_A(inst))) * sizeof(TString*) + offsetof(global_State, ttname)]);
+            build.mov(inst.regX64, qword[inst.regX64 + qwordReg(regOp(OP_A(inst))) * sizeof(TString*) + offsetof(global_State, ttypename)]);
         else if (OP_A(inst).kind == IrOpKind::Constant)
-            build.mov(inst.regX64, qword[inst.regX64 + tagOp(OP_A(inst)) * sizeof(TString*) + offsetof(global_State, ttname)]);
+            build.mov(inst.regX64, qword[inst.regX64 + tagOp(OP_A(inst)) * sizeof(TString*) + offsetof(global_State, ttypename)]);
         else
             CODEGEN_ASSERT(!"Unsupported instruction form");
         break;

--- a/CodeGen/src/IrUtils.cpp
+++ b/CodeGen/src/IrUtils.cpp
@@ -1017,7 +1017,7 @@ void foldConstants(IrBuilder& build, IrFunction& function, IrBlock& block, uint3
         {
             uint8_t a = function.tagOp(OP_A(inst));
 
-            if (a == LUA_TNIL)
+            if (a == LUA_TNIL || a == LUA_TSYMNONE)
                 substitute(function, inst, build.constInt(1));
             else if (a != LUA_TBOOLEAN)
                 substitute(function, inst, build.constInt(0));

--- a/CodeGen/src/OptimizeConstProp.cpp
+++ b/CodeGen/src/OptimizeConstProp.cpp
@@ -2058,7 +2058,7 @@ static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction&
     case IrCmd::JUMP_IF_TRUTHY:
         if (uint8_t tag = state.tryGetTag(OP_A(inst)); tag != 0xff)
         {
-            if (tag == LUA_TNIL)
+            if (tag == LUA_TNIL || tag == LUA_TSYMNONE)
                 replace(function, block, index, {IrCmd::JUMP, {OP_C(inst)}});
             else if (tag != LUA_TBOOLEAN)
                 replace(function, block, index, {IrCmd::JUMP, {OP_B(inst)}});
@@ -2067,7 +2067,7 @@ static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction&
     case IrCmd::JUMP_IF_FALSY:
         if (uint8_t tag = state.tryGetTag(OP_A(inst)); tag != 0xff)
         {
-            if (tag == LUA_TNIL)
+            if (tag == LUA_TNIL || tag == LUA_TSYMNONE)
                 replace(function, block, index, {IrCmd::JUMP, {OP_B(inst)}});
             else if (tag != LUA_TBOOLEAN)
                 replace(function, block, index, {IrCmd::JUMP, {OP_C(inst)}});
@@ -2783,7 +2783,7 @@ static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction&
     case IrCmd::SELECT_IF_TRUTHY:
         if (uint8_t tag = state.tryGetTag(OP_A(inst)); tag != 0xff)
         {
-            if (tag == LUA_TNIL)
+            if (tag == LUA_TNIL || tag == LUA_TSYMNONE)
                 substitute(function, inst, OP_C(inst));
             else if (tag != LUA_TBOOLEAN)
                 substitute(function, inst, OP_B(inst));

--- a/Compiler/src/Compiler.cpp
+++ b/Compiler/src/Compiler.cpp
@@ -441,6 +441,8 @@ struct Compiler
 
         argCount = localStack.size();
 
+        currentFunction = func;
+
         if (FFlag::LuauDefaultArguments)
             compileFunctionArgDefaults(func);
 
@@ -448,7 +450,6 @@ struct Compiler
 
         bool terminatesEarly = false;
         Location terminationLocation;
-        currentFunction = func;
 
         for (size_t i = 0; i < stat->body.size; ++i)
         {

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@
 
 - LuauExternallyManagedBuffers and LuauBufferIsFrozen: @cheesycod
 - LuauDefaultArguments: @Bottersnike
-- LuauExternTypeGenericMethods and LuauExternTypeUseDefinitionScope: @deviaze
+- LuauGenericNominals, LuauExternTypeGenericMethods, and LuauExternTypeUseDefinitionScope: @deviaze
 - LuauNonePrimitive: @cheesycod
 - LuauExternalString (and DebugLuauAllowNonNullTerminatedStrings for tests): @cheesycod
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,3 +4,4 @@
 
 - LuauExternallyManagedBuffers and LuauBufferIsFrozen: @cheesycod
 - LuauDefaultArguments: @Bottersnike
+- LuauExternTypeGenericMethods and LuauExternTypeUseDefinitionScope: @deviaze

--- a/VM/src/lstate.h
+++ b/VM/src/lstate.h
@@ -215,7 +215,8 @@ typedef struct global_State
     struct lua_State* mainthread;
     UpVal uvhead; // head of double-linked list of all open upvalues
     struct LuaTable* mt[LUA_T_COUNT]; // metatables for basic types
-    TString* ttname[LUA_T_COUNT]; // names for basic types
+    TString* ttname[LUA_T_COUNT]; // names for basic types, as returned by tostring()/error messages (LUA_TSYMNONE reports as "none")
+    TString* ttypename[LUA_T_COUNT]; // names for basic types, as returned by type() (matches luaT_typenames verbatim)
     TString* tmname[TM_N]; // array with tag-method names
 
     TValue pseudotemp; // storage for temporary values used in pseudo2addr

--- a/VM/src/ltm.cpp
+++ b/VM/src/ltm.cpp
@@ -76,6 +76,9 @@ void luaT_init(lua_State* L)
     {
         L->global->ttname[i] = luaS_new(L, i == LUA_TSYMNONE ? "none" : luaT_typenames[i]);
         luaS_fix(L->global->ttname[i]); // never collect these names
+
+        L->global->ttypename[i] = luaS_new(L, luaT_typenames[i]);
+        luaS_fix(L->global->ttypename[i]); // never collect these names
     }
     for (i = 0; i < TM_N; i++)
     {

--- a/VM/src/lvmutils.cpp
+++ b/VM/src/lvmutils.cpp
@@ -341,6 +341,7 @@ int luaV_equalval(lua_State* L, const TValue* t1, const TValue* t2)
     switch (ttype(t1))
     {
     case LUA_TNIL:
+    case LUA_TSYMNONE:
         return 1;
     case LUA_TNUMBER:
         return luai_numeq(nvalue(t1), nvalue(t2));

--- a/rfcx/README.md
+++ b/rfcx/README.md
@@ -1,5 +1,10 @@
-# Extra RFC's
+# Extra RFCs
 
 Extra RFC's implemented by mluau/luau that are not in the upstream luau-lang/luau repository.
 
-All extra RFCs should come with FFlags as well as a section in MAINTAINERS.md on who maintains/owns said extra RFC
+All extra RFCs should come with FFlags as well as a section in [MAINTAINERS.md](/MAINTAINERS.md) on who maintains/owns said extra RFC.
+
+Before making a PR, please add and discuss your feature in the `#features` channel in [hina & ferris discord server](https://discord.gg/3MJ37CFNWh)
+
+These RFCs should always come with both an RFC and a proposed implementation. If the feature has been proposed but doesn't have
+an implementation, we cannot add it in until it has an implementation. You can mark as draft until you have an implementation ready.

--- a/rfcx/TEMPLATE.md
+++ b/rfcx/TEMPLATE.md
@@ -1,5 +1,7 @@
 # Feature name
 
+FFlag: your fflag
+
 ## Summary
 
 One paragraph explanation of the feature.

--- a/rfcx/generics-on-extern-types.md
+++ b/rfcx/generics-on-extern-types.md
@@ -1,0 +1,71 @@
+# Generic parameters on extern types
+
+FFlags: LuauGenericNominals, LuauExternTypeGenericMethods
+
+Implementation-related upstream bugfix FFlags: LuauExternTypeUseDefinitionScope
+
+## Summary
+
+Allows nominal types (extern types and classes) to take generic parameters (like `<T>`).
+This first implementation focuses only on extern types, with a followup implementation adding support for user-defined classes.
+
+## Motivation
+
+Currently, putting generic parameters on extern types (defined by the embedder) causes a syntax error.
+The only way around it by using a generic parameter leakage hack...
+
+Generic extern types allow for a better, richer typed experience in error handling and any embedder defined type
+carrying data. They are also a LOT more readable than generic table types, and with the proposed implementation Rusty
+concepts like `Result<List<string>, IoError<string>>` just work AND are correctly handled in hovers.
+
+## Design
+
+Parser is extended to allow for generic parameters in 2 new locations, method `function Foo<T>(meow: Param): Ret` within `extern type` definitions
+as well as in extern type definitions themselves (`declare extern type Foo<T> with ... end`).
+
+The type solver is modified to handle generic parameters on extern types:
+
+- Generic parameters on extern types do not affect the runtime `typeof` of the extern type, and there's no way at runtime to recover what `T`
+an extern type was instantiated with. This feature only exists to improve strictly typed semantics.
+- Users may use `typeof` to refine a union of values including extern types with generic parameters to one or more extern types.
+- Generic parameters on classes are planned but not implemented in the first iteration of this RFC. We want to wait for our version of classes to land before implementing generic parameters on them.
+
+Example of using `typeof` to narrow:
+
+```luau
+--[[
+-- globals.d.luau
+declare extern type Exception<Data> with
+    inner: Data
+end
+]]
+
+const function can_fail(): string | Exception<{kind: "IoError"}> | Exception<"meow">
+    return nil :: any
+end
+
+const ress = can_fail()
+if typeof(ress) == "Exception" then
+    -- here ress is narrowed to Exception<{kind: "IoError"}> | Exception<"meow">
+    if typeof(ress.inner) == "string" then
+        -- here ress is narrowed to Exception<"meow">
+        const y = ress.inner
+    else
+        -- here ress is narrowed to Exception<{kind: "IoError"}>
+        const x = ress.inner
+    end
+end
+```
+
+## Drawbacks
+
+This is a major change to the type solver and will significantly affect our ability to merge patches from upstream.
+Additionally, since generic parameters are not known at runtime one can say that implementing generic parameters on extern types is
+technically incorrect. We feel that the benefits outweigh the drawbacks or technical correctness in this case.
+
+## Alternatives
+
+- the existing generics hack,
+- waiting for classes to be fully implemented and then implementing them for both types of nominals
+- only supporting generic parameters on methods inside extern types but not on the extern types themselves
+- not supporting generic parameters on extern types

--- a/tests/Compiler.test.cpp
+++ b/tests/Compiler.test.cpp
@@ -28,6 +28,7 @@ LUAU_FASTFLAG(LuauIntegerFastcalls)
 LUAU_FASTFLAG(LuauIntegerBufferFastcalls)
 LUAU_FASTFLAG(LuauCompileStringInterpTargetTop)
 LUAU_FASTFLAG(LuauExportValueSyntax)
+LUAU_FASTFLAG(LuauExportedClassIsNilWorkaround)
 LUAU_FASTFLAG(DebugLuauNoInline)
 LUAU_FASTFLAG(LuauEmitCallFeedback)
 LUAU_FASTFLAG(LuauDefaultArguments)
@@ -11958,6 +11959,7 @@ TEST_CASE("ExportClass")
     ScopedFastFlag sffs[] = {
         {FFlag::LuauExportValueSyntax, true},
         {FFlag::DebugLuauUserDefinedClasses, true},
+        {FFlag::LuauExportedClassIsNilWorkaround, false},
     };
 
     CHECK_EQ(

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -1260,35 +1260,6 @@ TEST_CASE("Math")
     runConformance("math.luau");
 }
 
-TEST_CASE("Integers")
-{
-    ScopedFastFlag ncgBufferInteger{FFlag::LuauCodegenBufferInteger, true};
-    ScopedFastFlag luauCodegenFixBufferLenCheck{FFlag::LuauCodegenFixBufferLenCheck, true};
-
-    if (FFlag::LuauIntegerType2 && FFlag::LuauIntegerLibrary)
-    {
-        runConformance(
-            "integers.luau",
-            [](lua_State* L)
-            {
-                setupNativeHelpers(L);
-            }
-        );
-
-        if (codegen && luau_codegen_supported())
-        {
-            runConformance(
-                "integers_regspill.luau",
-
-                [](lua_State* L)
-                {
-                    setupNativeHelpers(L);
-                }
-            );
-        }
-    }
-}
-
 TEST_CASE("Tables")
 {
     runConformance(

--- a/tests/ExternalString.test.cpp
+++ b/tests/ExternalString.test.cpp
@@ -18,6 +18,11 @@ static void test_string_free_cb(lua_State* L, const char* data, size_t sz, void*
     s_externalStringFreeCount++;
 }
 
+static void test_string_free_delete_cb(lua_State* L, const char* data, size_t sz, void* userdata)
+{
+    delete[] data;
+}
+
 static int dostring(lua_State* L, const char* code)
 {
     size_t bytecodeSize = 0;
@@ -172,7 +177,7 @@ TEST_CASE("ExternalStringBuffinishOverread")
     char* my_string = new char[content.size()];
     memcpy(my_string, content.data(), content.size());
 
-    lua_pushexternalstring(L, my_string, content.size(), nullptr, test_string_free_cb);
+    lua_pushexternalstring(L, my_string, content.size(), nullptr, test_string_free_delete_cb);
     lua_setglobal(L, "ext_str");
 
     // build an equal-content, equal-length string via runtime concatenation so it

--- a/tests/IrLowering.test.cpp
+++ b/tests/IrLowering.test.cpp
@@ -5504,8 +5504,7 @@ bb_bytecode_1:
 
 TEST_CASE_FIXTURE(LoweringFixture, "BufferSanityPositive")
 {
-    CHECK_EQ(
-        "\n" + getCodegenAssembly(R"(
+    const char* source = R"(
 local function foo(zero: number, b1: buffer, b2: buffer)
     buffer.writei8(b1, zero + 0, buffer.readi8(b1, zero + 0))
     buffer.writeu8(b1, zero + 0, buffer.readu8(b1, zero + 0))
@@ -5517,8 +5516,76 @@ local function foo(zero: number, b1: buffer, b2: buffer)
     buffer.writei16(b2, zero + 0, buffer.readi16(b2, zero + 0))
     buffer.writeu16(b2, zero + 0, buffer.readu16(b2, zero + 0))
 end
-)"),
-        R"(
+)";
+
+    // With LuauCodegenVmExitSyncMultiUse, the dead store optimizer recognizes that the
+    // redundant `zero + 0` (%11) can be dropped in favor of reusing %10 directly at every
+    // exit sync site, instead of keeping the extra ADD_NUM alive.
+    if (FFlag::LuauCodegenVmExitSyncMultiUse)
+    {
+        CHECK_EQ(
+            "\n" + getCodegenAssembly(source),
+            R"(
+; function foo($arg0, $arg1, $arg2) line 2
+bb_0:
+  CHECK_TAG R0, tnumber, exit(entry)
+  CHECK_TAG R1, tbuffer, exit(entry)
+  CHECK_TAG R2, tbuffer, exit(entry)
+  JUMP bb_2
+bb_2:
+  JUMP bb_bytecode_1
+bb_bytecode_1:
+  implicit CHECK_SAFE_ENV exit(0)
+  %10 = LOAD_DOUBLE R0
+  %25 = LOAD_POINTER R1
+  %27 = NUM_TO_INT %10
+  CHECK_BUFFER_LEN %25, %27, 0i, 1i, undef, bb_exit_19
+   ; exit sync: R8, R5, {%10}
+  %29 = BUFFER_READI8 %25, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %25, bb_exit_20
+   ; exit sync: R6, R5, {%29, %10}
+  BUFFER_WRITEI8 %25, %27, %29, tbuffer
+  %71 = BUFFER_READU8 %25, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %25, bb_exit_21
+   ; exit sync: R6, {%71}
+  BUFFER_WRITEI8 %25, %27, %71, tbuffer
+  %109 = LOAD_POINTER R2
+  CHECK_BUFFER_LEN %109, %27, 0i, 2i, %10, exit(32)
+  %113 = BUFFER_READI8 %109, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %109, bb_exit_22
+   ; exit sync: R6, {%113}
+  BUFFER_WRITEI8 %109, %27, %113, tbuffer
+  %155 = BUFFER_READU8 %109, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %109, bb_exit_23
+   ; exit sync: R6, {%155}
+  BUFFER_WRITEI8 %109, %27, %155, tbuffer
+  %195 = ADD_INT %27, 1i
+  %197 = BUFFER_READI8 %109, %195, tbuffer
+  CHECK_BUFFER_MUTABLE %109, bb_exit_24
+   ; exit sync: R6, R5, {%197, %10}
+  BUFFER_WRITEI8 %109, %195, %197, tbuffer
+  %239 = BUFFER_READU8 %109, %195, tbuffer
+  CHECK_BUFFER_MUTABLE %109, bb_exit_25
+   ; exit sync: R6, {%239}
+  BUFFER_WRITEI8 %109, %195, %239, tbuffer
+  %281 = BUFFER_READI16 %109, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %109, bb_exit_26
+   ; exit sync: R6, R5, {%281, %10}
+  BUFFER_WRITEI16 %109, %27, %281, tbuffer
+  %323 = BUFFER_READU16 %109, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %109, bb_exit_27
+   ; exit sync: R6, {%323}
+  BUFFER_WRITEI16 %109, %27, %323, tbuffer
+  INTERRUPT 112u
+  RETURN R0, 0i
+)"
+        );
+    }
+    else
+    {
+        CHECK_EQ(
+            "\n" + getCodegenAssembly(source),
+            R"(
 ; function foo($arg0, $arg1, $arg2) line 2
 bb_0:
   CHECK_TAG R0, tnumber, exit(entry)
@@ -5573,7 +5640,8 @@ bb_bytecode_1:
   INTERRUPT 112u
   RETURN R0, 0i
 )"
-    );
+        );
+    }
 }
 
 TEST_CASE_FIXTURE(LoweringFixture, "BufferSanityNegative")

--- a/tests/Normalize.test.cpp
+++ b/tests/Normalize.test.cpp
@@ -722,7 +722,7 @@ TEST_CASE_FIXTURE(NormalizeFixture, "negated_function_is_anything_except_a_funct
 {
     if (FFlag::LuauIntegerType2)
     {
-        CHECK("(boolean | buffer | integer | number | string | table | thread | userdata)?" == toString(normal(R"(
+        CHECK("(boolean | buffer | integer | none | number | string | table | thread | userdata)?" == toString(normal(R"(
         Not<fun>
     )")));
     }
@@ -756,7 +756,7 @@ TEST_CASE_FIXTURE(NormalizeFixture, "bare_negated_boolean")
 {
     if (FFlag::LuauIntegerType2)
     {
-        CHECK("(buffer | function | integer | number | string | table | thread | userdata)?" == toString(normal(R"(
+        CHECK("(buffer | function | integer | none | number | string | table | thread | userdata)?" == toString(normal(R"(
             Not<boolean>
         )")));
     }
@@ -929,15 +929,18 @@ TEST_CASE_FIXTURE(NormalizeFixture, "negations_of_extern_types")
 
     if (FFlag::LuauIntegerType2)
     {
-        CHECK("((userdata & ~Child) | boolean | buffer | function | integer | number | string | table | thread)?" == toString(normal("Not<Child>")));
+        CHECK(
+            "((userdata & ~Child) | boolean | buffer | function | integer | none | number | string | table | thread)?" ==
+            toString(normal("Not<Child>"))
+        );
         CHECK("never" == toString(normal("Not<Parent> & Child")));
         CHECK(
-            "((userdata & ~Parent) | Child | boolean | buffer | function | integer | number | string | table | thread)?" ==
+            "((userdata & ~Parent) | Child | boolean | buffer | function | integer | none | number | string | table | thread)?" ==
             toString(normal("Not<Parent> | Child"))
         );
-        CHECK("(boolean | buffer | function | integer | number | string | table | thread)?" == toString(normal("Not<cls>")));
+        CHECK("(boolean | buffer | function | integer | none | number | string | table | thread)?" == toString(normal("Not<cls>")));
         CHECK(
-            "(Parent | Unrelated | boolean | buffer | function | integer | number | string | table | thread)?" ==
+            "(Parent | Unrelated | boolean | buffer | function | integer | none | number | string | table | thread)?" ==
             toString(normal("Not<cls & Not<Parent> & Not<Child> & Not<Unrelated>>"))
         );
     }
@@ -981,7 +984,7 @@ TEST_CASE_FIXTURE(NormalizeFixture, "negations_of_tables")
 {
     CHECK(nullptr == toNormalizedType("Not<{}>", !FFlag::DebugLuauForceOldSolver ? 1 : 0));
     if (FFlag::LuauIntegerType2)
-        CHECK("(boolean | buffer | function | integer | number | string | thread | userdata)?" == toString(normal("Not<tbl>")));
+        CHECK("(boolean | buffer | function | integer | none | number | string | thread | userdata)?" == toString(normal("Not<tbl>")));
     else
         CHECK("(boolean | buffer | function | none | number | string | thread | userdata)?" == toString(normal("Not<tbl>")));
     CHECK("table" == toString(normal("Not<Not<tbl>>")));

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -25,6 +25,7 @@ LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
 LUAU_FASTFLAG(LuauTrackPrefixLocal)
 LUAU_FASTFLAG(LuauDefaultArguments)
 LUAU_FASTFLAG(LuauExternTypeGenericMethods)
+LUAU_FASTFLAG(LuauGenericNominals)
 
 LUAU_FASTFLAG(LuauNoDuplicateBinaryPrefix)
 
@@ -2749,6 +2750,92 @@ TEST_CASE_FIXTURE(Fixture, "extern_type_generic_property_syntax_workaround_is_un
     REQUIRE(meow != nullptr);
     REQUIRE_EQ(1, meow->generics.size);
     CHECK_EQ(meow->generics.data[0]->name, "T");
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_are_gated")
+{
+    matchParseError(
+        R"(
+        declare extern type Box<T> with
+            value: T
+        end
+        )",
+        "Expected `with` keyword before listing properties of the external type, but got (null) instead"
+    );
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics")
+{
+    ScopedFastFlag sff{FFlag::LuauGenericNominals, true};
+
+    AstStatBlock* stat = parseEx(R"(
+        declare extern type Box<T> with
+            value: T
+        end
+    )")
+                             .root;
+
+    REQUIRE(stat != nullptr);
+    REQUIRE_EQ(1, stat->body.size);
+
+    AstStatDeclareExternType* box = stat->body.data[0]->as<AstStatDeclareExternType>();
+    REQUIRE(box != nullptr);
+    REQUIRE_EQ(1, box->generics.size);
+    CHECK_EQ(box->generics.data[0]->name, "T");
+    CHECK_EQ(0, box->genericPacks.size);
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_support_multiple_params_and_packs")
+{
+    ScopedFastFlag sff{FFlag::LuauGenericNominals, true};
+
+    AstStatBlock* stat = parseEx(R"(
+        declare extern type Result<T, E, Rest...> with
+            value: T
+        end
+    )")
+                             .root;
+
+    REQUIRE(stat != nullptr);
+    REQUIRE_EQ(1, stat->body.size);
+
+    AstStatDeclareExternType* result = stat->body.data[0]->as<AstStatDeclareExternType>();
+    REQUIRE(result != nullptr);
+    REQUIRE_EQ(2, result->generics.size);
+    CHECK_EQ(result->generics.data[0]->name, "T");
+    CHECK_EQ(result->generics.data[1]->name, "E");
+    REQUIRE_EQ(1, result->genericPacks.size);
+    CHECK_EQ(result->genericPacks.data[0]->name, "Rest");
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_and_method_generics_together")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::LuauGenericNominals, true},
+        {FFlag::LuauExternTypeGenericMethods, true},
+    };
+
+    AstStatBlock* stat = parseEx(R"(
+        declare extern type Box<T> with
+            value: T
+            function map<U>(self, f: (T) -> U): Box<U>
+        end
+    )")
+                             .root;
+
+    REQUIRE(stat != nullptr);
+    REQUIRE_EQ(1, stat->body.size);
+
+    AstStatDeclareExternType* box = stat->body.data[0]->as<AstStatDeclareExternType>();
+    REQUIRE(box != nullptr);
+    REQUIRE_EQ(1, box->generics.size);
+    CHECK_EQ(box->generics.data[0]->name, "T");
+    REQUIRE_EQ(2, box->props.size);
+
+    AstTypeFunction* map = box->props.data[1].ty->as<AstTypeFunction>();
+    REQUIRE(map != nullptr);
+    REQUIRE_EQ(1, map->generics.size);
+    CHECK_EQ(map->generics.data[0]->name, "U");
 }
 
 TEST_CASE_FIXTURE(Fixture, "missing_declaration_prop")

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -2157,7 +2157,10 @@ TEST_CASE_FIXTURE(Fixture, "parse_declarations")
 
 TEST_CASE_FIXTURE(Fixture, "default_arguments_are_gated")
 {
-    matchParseError("local function foo(x = 1) end", "Expected ')' (to close '(' at column 19), got '='");
+    {
+        ScopedFastFlag sff{FFlag::LuauDefaultArguments, false};
+        matchParseError("local function foo(x = 1) end", "Expected ')' (to close '(' at column 19), got '='");
+    }
 
     ScopedFastFlag sff{FFlag::LuauDefaultArguments, true};
 
@@ -2630,6 +2633,8 @@ TEST_CASE_FIXTURE(Fixture, "variadic_definition_parsing")
 
 TEST_CASE_FIXTURE(Fixture, "extern_type_generic_methods_are_gated")
 {
+    ScopedFastFlag sff{FFlag::LuauExternTypeGenericMethods, false};
+
     matchParseError(
         R"(
         declare extern type Cat with
@@ -2754,6 +2759,8 @@ TEST_CASE_FIXTURE(Fixture, "extern_type_generic_property_syntax_workaround_is_un
 
 TEST_CASE_FIXTURE(Fixture, "extern_type_generics_are_gated")
 {
+    ScopedFastFlag sff{FFlag::LuauGenericNominals, false};
+
     matchParseError(
         R"(
         declare extern type Box<T> with

--- a/tests/Parser.test.cpp
+++ b/tests/Parser.test.cpp
@@ -24,6 +24,7 @@ LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
 LUAU_FASTFLAG(LuauTrackPrefixLocal)
 LUAU_FASTFLAG(LuauDefaultArguments)
+LUAU_FASTFLAG(LuauExternTypeGenericMethods)
 
 LUAU_FASTFLAG(LuauNoDuplicateBinaryPrefix)
 
@@ -2624,6 +2625,130 @@ TEST_CASE_FIXTURE(Fixture, "variadic_definition_parsing")
 
     matchParseError("declare function foo(...)", "All declaration parameters must be annotated");
     matchParseError("declare extern type Foo with function a(self, ...) end", "All declaration parameters aside from 'self' must be annotated");
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_methods_are_gated")
+{
+    matchParseError(
+        R"(
+        declare extern type Cat with
+            function meow<T>(self): T
+        end
+        )",
+        "Expected '(' when parsing function parameter list start, got '<'"
+    );
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_methods")
+{
+    ScopedFastFlag sff{FFlag::LuauExternTypeGenericMethods, true};
+
+    AstStatBlock* stat = parseEx(R"(
+        declare extern type Cat with
+            function meow<T>(self): T
+            function purr(self): number
+        end
+    )")
+                             .root;
+
+    REQUIRE(stat != nullptr);
+    REQUIRE_EQ(1, stat->body.size);
+
+    AstStatDeclareExternType* cat = stat->body.data[0]->as<AstStatDeclareExternType>();
+    REQUIRE(cat != nullptr);
+    REQUIRE_EQ(2, cat->props.size);
+
+    AstTypeFunction* meow = cat->props.data[0].ty->as<AstTypeFunction>();
+    REQUIRE(meow != nullptr);
+    REQUIRE_EQ(1, meow->generics.size);
+    CHECK_EQ(meow->generics.data[0]->name, "T");
+    CHECK_EQ(0, meow->genericPacks.size);
+
+    // Non-generic methods are unaffected by the flag.
+    AstTypeFunction* purr = cat->props.data[1].ty->as<AstTypeFunction>();
+    REQUIRE(purr != nullptr);
+    CHECK_EQ(0, purr->generics.size);
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_method_packs")
+{
+    ScopedFastFlag sff{FFlag::LuauExternTypeGenericMethods, true};
+
+    AstStatBlock* stat = parseEx(R"(
+        declare extern type Cat with
+            function meow<T...>(self, ...: T...): (T...)
+        end
+    )")
+                             .root;
+
+    REQUIRE(stat != nullptr);
+    REQUIRE_EQ(1, stat->body.size);
+
+    AstStatDeclareExternType* cat = stat->body.data[0]->as<AstStatDeclareExternType>();
+    REQUIRE(cat != nullptr);
+    REQUIRE_EQ(1, cat->props.size);
+
+    AstTypeFunction* meow = cat->props.data[0].ty->as<AstTypeFunction>();
+    REQUIRE(meow != nullptr);
+    CHECK_EQ(0, meow->generics.size);
+    REQUIRE_EQ(1, meow->genericPacks.size);
+    CHECK_EQ(meow->genericPacks.data[0]->name, "T");
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_methods_support_multiple_params")
+{
+    ScopedFastFlag sff{FFlag::LuauExternTypeGenericMethods, true};
+
+    AstStatBlock* stat = parseEx(R"(
+        declare extern type Cat with
+            function meow<T, U>(self, whatever: U): T
+        end
+    )")
+                             .root;
+
+    REQUIRE(stat != nullptr);
+    REQUIRE_EQ(1, stat->body.size);
+
+    AstStatDeclareExternType* cat = stat->body.data[0]->as<AstStatDeclareExternType>();
+    REQUIRE(cat != nullptr);
+    REQUIRE_EQ(1, cat->props.size);
+
+    AstTypeFunction* meow = cat->props.data[0].ty->as<AstTypeFunction>();
+    REQUIRE(meow != nullptr);
+    REQUIRE_EQ(2, meow->generics.size);
+    CHECK_EQ(meow->generics.data[0]->name, "T");
+    CHECK_EQ(meow->generics.data[1]->name, "U");
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_property_syntax_workaround_is_unaffected_by_the_flag")
+{
+    // Properties declared with `name: <T>(...) -> ...` syntax (rather than the `function name<T>(...)` sugar)
+    // go through the general-purpose parseType() -> parseFunctionType() path, which has always supported
+    // its own generics. This is the workaround referenced in issue #8 for getting generic methods on extern
+    // types prior to LuauExternTypeGenericMethods; it works today regardless of the flag, and continues to
+    // work once class-level generics land, since it's parsed independently of `function`-sugared methods.
+    AstStatBlock* stat = parseEx(R"(
+        declare extern type Cat with
+            meow: <T>(self: Cat, whatever: T) -> T
+        end
+    )")
+                             .root;
+
+    REQUIRE(stat != nullptr);
+    REQUIRE_EQ(1, stat->body.size);
+
+    AstStatDeclareExternType* cat = stat->body.data[0]->as<AstStatDeclareExternType>();
+    REQUIRE(cat != nullptr);
+    REQUIRE_EQ(1, cat->props.size);
+
+    // Property-syntax members are not implicitly treated as methods: no 'self' is injected,
+    // so the annotation must (and does, above) spell it out explicitly.
+    CHECK(!cat->props.data[0].isMethod);
+
+    AstTypeFunction* meow = cat->props.data[0].ty->as<AstTypeFunction>();
+    REQUIRE(meow != nullptr);
+    REQUIRE_EQ(1, meow->generics.size);
+    CHECK_EQ(meow->generics.data[0]->name, "T");
 }
 
 TEST_CASE_FIXTURE(Fixture, "missing_declaration_prop")

--- a/tests/TypeInfer.externTypes.test.cpp
+++ b/tests/TypeInfer.externTypes.test.cpp
@@ -1278,7 +1278,11 @@ TEST_CASE_FIXTURE(Fixture, "extern_type_generic_method_property_syntax_still_bro
 {
     // Without the fix, `T` fails to resolve while checking the definition file itself
     // (not the code that uses Cat), so loading the definition file is where this fails.
-    ScopedFastFlag sff{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, false},
+        {FFlag::LuauGenericNominals, false},
+    };
 
     unfreeze(getFrontend().globals.globalTypes);
     LoadDefinitionFileResult loadResult = getFrontend().loadDefinitionFile(

--- a/tests/TypeInfer.externTypes.test.cpp
+++ b/tests/TypeInfer.externTypes.test.cpp
@@ -2,6 +2,7 @@
 #include "Luau/BuiltinDefinitions.h"
 #include "Luau/Common.h"
 #include "Luau/Error.h"
+#include "Luau/ExperimentalFlags.h"
 #include "Luau/TypeInfer.h"
 #include "Luau/Type.h"
 
@@ -11,6 +12,8 @@
 #include "ScopedFlags.h"
 #include "doctest.h"
 
+#include <cstring>
+
 using namespace Luau;
 using std::nullopt;
 
@@ -18,6 +21,9 @@ LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauDropUnionSubtypeReasoning)
 LUAU_FASTFLAG(LuauExternTypeGenericMethods)
 LUAU_FASTFLAG(LuauExternTypeUseDefinitionScope)
+LUAU_FASTFLAG(LuauGenericNominals)
+LUAU_FASTFLAG(LuauHigherOrderGenericInference)
+LUAU_FASTFLAG(LuauSolverV2)
 
 TEST_SUITE_BEGIN("TypeInferExternTypes");
 
@@ -1424,6 +1430,488 @@ TEST_CASE_FIXTURE(Fixture, "extern_type_generic_method_explicit_instantiation_mi
     )");
 
     LUAU_REQUIRE_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_instantiate")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Box<T> with
+            value: T
+        end
+
+        declare Box: {
+            new: <T>(value: T) -> Box<T>
+        }
+    )");
+
+    CheckResult result = check(R"(
+        local b = Box.new(5)
+        local x = b.value
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("Box<number>", toString(requireType("b")));
+    CHECK_EQ("number", toString(requireType("x")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_nested_instantiation")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Box<T> with
+            value: T
+        end
+
+        declare Box: {
+            new: <T>(value: T) -> Box<T>
+        }
+    )");
+
+    CheckResult result = check(R"(
+        type Nested = Box<Box<string>>
+        local n = (nil :: any) :: Nested
+        local inner = n.value
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("Box<Box<string>>", toString(requireType("n")));
+    CHECK_EQ("Box<string>", toString(requireType("inner")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_nested_instantiation_with_unused_param")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+    };
+
+    // `T` does not appear anywhere in Result's own body, so the type argument used to
+    // instantiate the outer Result<...> is the only place a nested, still-unresolved
+    // generic instantiation (like `Result<string>`) can be found.
+    loadDefinition(R"(
+        declare extern type Result<T> with
+            cats: string
+        end
+    )");
+
+    CheckResult result = check(R"(
+        type meow = Result<Result<string>>
+        local meo = (nil :: any) :: meow
+        local cats = meo.cats
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("Result<Result<string>>", toString(requireType("meo")));
+    CHECK_EQ("string", toString(requireType("cats")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_two_params_with_method")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Result<Ok, Err> with
+            inner: Ok | Err
+            function is_ok(self): boolean
+            function expect(self, assertion: string?): Ok
+        end
+
+        declare function try_<T, E>(f: () -> T): Result<T, E>
+    )");
+
+    CheckResult result = check(R"(
+        local function get_sketchy(): string
+            return "x"
+        end
+
+        local r = try_(get_sketchy)
+        if r:is_ok() then
+            local response = r:expect()
+        end
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_explicit_partial_instantiation_KNOWN_BUG_produces_cyclic_type")
+{
+    // KNOWN BUG, not yet fixed: explicitly instantiating only a leading subset of a function's
+    // generics (e.g. `try_<<string>>(...)`, pinning E and leaving Args/T to be inferred) while its
+    // return type expands a generic nominal type (`declare extern type Result<Ok, Err> with ...`)
+    // produces a corrupted, self-referential result type (toString shows `Result<Result<*CYCLE*>,
+    // string>` -- guarded against hanging/unbounded output by the cycle check in ToString.cpp, but
+    // the underlying type is still wrong) and an "outstanding free or blocked type" internal error
+    // from TypeChecker2 on any subsequent method call. Traced to a single TypeAliasExpansionConstraint
+    // dispatch for `Result<T, E>` whose own `T` argument ends up bound back to the result type itself
+    // -- likely a Unifier2/instantiate2 issue unifying a still-pending return type against the fresh
+    // inferred return pack, not something in the substitution/display work this test file otherwise
+    // covers. The identical explicit-partial-instantiation pattern against a plain table return type
+    // works correctly, so this is specific to generic nominal (extern type) expansion.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Result<Ok, Err> with
+            inner: Ok | Err
+            function is_ok(self): boolean
+            function expect(self, assertion: string?): Ok
+        end
+
+        declare function try_<E, Args, T>(f: (...Args) -> T, ...: Args): Result<T, E>
+    )");
+
+    CheckResult result = check(R"(
+        local function get_sketchy(url: string): string
+            return "x"
+        end
+
+        local r = try_<<string>>(get_sketchy, "someurl")
+        if r:is_ok() then
+            local response = r:expect()
+        end
+    )");
+
+    // Once fixed, this should be LUAU_CHECK_NO_ERRORS(result) with r typed as Result<string, string>.
+    CHECK(!result.errors.empty());
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_independent_instantiations_are_compatible")
+{
+    // Two independently-produced clones of the same generic nominal instantiation (one from
+    // resolving the `List<string>` annotation, one from substituting the vararg constructor's
+    // return type) are different TypeIds but must still be recognized as the same nominal type.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+        {FFlag::LuauHigherOrderGenericInference, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type List<T> with
+            function get(self, idx: number): T?
+        end
+
+        declare list: {
+            new: <T>(...T) -> List<T>,
+        }
+    )");
+
+    CheckResult result = check(R"(
+        local listy: List<string> = list.new("cats", "dogs")
+        local res = listy:get(1)
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("List<string>", toString(requireType("listy")));
+    CHECK_EQ("string?", toString(requireType("res")));
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "extern_type_generics_typeof_refines_generic_instantiation")
+{
+    // `typeof(x) == "ClassName"` refinement already narrows unions for non-generic extern
+    // types; it used to silently do nothing for generic ones because the lookup that finds the
+    // class by name required `typeFun->typeParams.empty()`, which is never true for a generic
+    // extern type's TypeFun.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+        {FFlag::LuauHigherOrderGenericInference, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Exception<Data> with
+            inner: Data
+        end
+    )");
+
+    CheckResult result = check(R"(
+        local function can_fail(): string | Exception<{kind: string}>
+            return nil :: any
+        end
+
+        local ress = can_fail()
+        if typeof(ress) == "Exception" then
+            local inner = ress.inner
+            local k = inner.kind
+        end
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_unconstrained_generic_resolved_from_expected_type")
+{
+    // A generic that only appears in the return type, never in any argument (e.g. `E` in
+    // `function ok<T, E>(value: T): Result<T, E>`), has nothing to bind it at the call site,
+    // so it used to default to `unknown` -- which then failed a subtype check against whatever
+    // the call's surrounding context actually expected. If the call site has a known expected
+    // type shaped like the same generic nominal type, that should resolve the otherwise-free
+    // generic instead.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+        {FFlag::LuauHigherOrderGenericInference, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type List<T> with
+            function front(self): T?
+        end
+
+        declare list: {
+            new: <T>(...T) -> List<T>,
+        }
+
+        declare extern type Result<T, E> with
+            function is_ok(self): boolean
+        end
+
+        declare result: {
+            ok: <T, E>(ok: T) -> Result<T, E>,
+        }
+    )");
+
+    CheckResult result = check(R"(
+        local list_res: Result<List<string>, string> = result.ok(list.new("cats", "dogs"))
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("Result<List<string>, string>", toString(requireType("list_res")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_independent_instantiations_are_compatible_when_nested")
+{
+    // Same idea as extern_type_generics_independent_instantiations_are_compatible, but the
+    // mismatched clones are *nested inside another generic nominal type's type arguments*
+    // (`Result<string, Option<T>>`), so isSameGenericNominalInstantiation must compare those
+    // type arguments recursively (via nominal identity) rather than by raw TypeId/follow()
+    // equality, since two `Option<T>` instantiations built at different call sites are
+    // different TypeIds.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+        {FFlag::LuauHigherOrderGenericInference, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type List<T> with
+            function front(self): T?
+        end
+
+        declare list: {
+            new: <T>(...T) -> List<T>,
+        }
+
+        declare extern type Option<T> with
+            function try_some(self): T?
+        end
+
+        declare option: {
+            some: <T>(T) -> Option<T>,
+        }
+
+        declare extern type Result<T, E> with
+            function is_ok(self): boolean
+        end
+
+        declare result: {
+            err: <T, E>(err: E) -> Result<T, E>,
+        }
+    )");
+
+    CheckResult result = check(R"(
+        local function get(): Result<string, Option<List<string>>>
+            local listy = list.new("cats", "dogs")
+            return result.err<<string, Option<List<string>>>>(option.some(listy))
+        end
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_vararg_constructor_method_only_generic")
+{
+    // Covers a combination the other tests in this file don't: a vararg generic constructor
+    // (`<T>(...T) -> List<T>`), a forward reference (`list` declared before `List<T>` itself,
+    // matching how real-world definition files are usually written), and a generic that only
+    // appears inside a method's signature (`function get(self, idx): T?`), never in a plain
+    // field. All three needed their own fix:
+    //  - Tarjan::visitChildren (Substitution.cpp) never walked ExternType::instantiatedTypeParams,
+    //    so dirty-detection could miss a generic that's otherwise only reachable through it.
+    //  - Clone.cpp's cloneChildren(ExternType*) never remapped instantiatedTypeParams/PackParams
+    //    through shallowClone, so a deep-cloned instance (e.g. at a call site) kept pointing at
+    //    the pre-clone generic instead of the fresh one used everywhere else in the clone.
+    // Also enables every FFlag the way luau-lsp's --flag-enabled-by-default does (see
+    // Luau::isAnalysisFlagExperimental), since a narrower hand-picked flag set didn't reproduce
+    // this; something else enabled by that broader set (not yet identified) was also load-bearing.
+    std::vector<ScopedFastFlag> allFlags;
+    for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
+    {
+        if (strncmp(flag->name, "Luau", 4) == 0 && !Luau::isAnalysisFlagExperimental(flag->name))
+            allFlags.emplace_back(*flag, true);
+    }
+    ScopedFastFlag solverV2{FFlag::LuauSolverV2, true};
+
+    loadDefinition(R"(
+        declare list: {
+            new: <T>(...T) -> List<T>,
+        }
+
+        declare extern type List<T> with
+            function get(self, idx: number): T?
+        end
+    )");
+
+    CheckResult result = check(R"(
+        local listy: List<string> = list.new("cats", "dogs")
+        local res = listy:get(1)
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("List<string>", toString(requireType("listy")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_method_with_own_generic_does_not_corrupt_constructors")
+{
+    // Regression test: a method with its own generic (`map<To>(self): Option<To>`) on a generic
+    // extern type used to make InfiniteTypeFinder mistake the method's own generic `To` for a
+    // recursive/infinite expansion of `Option`, silently binding `Option<T>` to *error-type*
+    // with no diagnostics anywhere, which broke every constructor call (`option.some(...)`).
+    std::vector<ScopedFastFlag> allFlags;
+    for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
+    {
+        if (strncmp(flag->name, "Luau", 4) == 0 && !Luau::isAnalysisFlagExperimental(flag->name))
+            allFlags.emplace_back(*flag, true);
+    }
+    ScopedFastFlag solverV2{FFlag::LuauSolverV2, true};
+
+    auto defResult = loadDefinition(R"(
+        declare option: {
+            some: <T>(T) -> Option<T>,
+            none: <T>() -> Option<T>
+        }
+
+        declare extern type Option<T> with
+            inner: T?
+            function map<To>(self): Option<To>
+            function unwrap_or(self, default: T): T
+        end
+    )");
+
+    REQUIRE(defResult.module != nullptr);
+    CHECK(defResult.module->errors.empty());
+
+    CheckResult result = check(R"(
+        local somee = option.some("hello")
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("Option<string>", toString(requireType("somee")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_method_self_type_is_parameterized")
+{
+    // A generic extern type's methods implicitly take `self`. `self` needs to be typed as
+    // `ListGivesOption<T>` (applied to the type's own generics), not the bare, unparameterized
+    // `ListGivesOption` -- otherwise calling a method on a properly-instantiated `ListGivesOption<string>`
+    // fails to match against `self`, since the two would be nominally unrelated.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+        {FFlag::LuauHigherOrderGenericInference, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Option<T> with
+            inner: T?
+            function unwrap_or(self, default: T): T
+        end
+
+        declare extern type ListGivesOption<T> with
+            function get(self, idx: number): Option<T>
+        end
+
+        declare list: {
+            new_returns_option: <T>(...T) -> ListGivesOption<T>,
+        }
+    )");
+
+    CheckResult result = check(R"(
+        local listyy: ListGivesOption<string> = list.new_returns_option("cats", "dogs")
+        local opt = listyy:get(1)
+        local val = opt:unwrap_or("default")
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("string", toString(requireType("val")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generics_do_not_crash_old_solver")
+{
+    // The old solver never reads AstStatDeclareExternType::generics/genericPacks, so it should
+    // just silently treat a generic extern type as non-generic (and referencing it with type
+    // arguments should produce an ordinary user-facing type error, not a crash). This test only
+    // asserts we don't crash/assert; it deliberately does not assert on the resulting types,
+    // since the old solver isn't expected to actually support this feature. Confirmed by hand
+    // that this currently produces ordinary UnknownSymbol/IncorrectGenericParameterCount errors,
+    // not a crash.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, true},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauGenericNominals, true},
+        {FFlag::LuauExternTypeGenericMethods, true},
+    };
+
+    unfreeze(getFrontend().globals.globalTypes);
+    LoadDefinitionFileResult loadResult = getFrontend().loadDefinitionFile(
+        getFrontend().globals, getFrontend().globals.globalScope, R"(
+        declare extern type Box<T> with
+            function map<U>(self, f: (T) -> U): Box<U>
+        end
+
+        declare Box: {
+            new: <T>(value: T) -> Box<T>
+        }
+    )",
+        "@test",
+        /* captureComments */ false,
+        /* typecheckForAutocomplete */ false
+    );
+    freeze(getFrontend().globals.globalTypes);
+
+    if (!loadResult.success)
+        return;
+
+    CheckResult result = check(R"(
+        local b = Box.new(5)
+        local x = b:map(function(v) return tostring(v) end)
+    )");
+
+    (void)result;
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.externTypes.test.cpp
+++ b/tests/TypeInfer.externTypes.test.cpp
@@ -16,6 +16,8 @@ using std::nullopt;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauDropUnionSubtypeReasoning)
+LUAU_FASTFLAG(LuauExternTypeGenericMethods)
+LUAU_FASTFLAG(LuauExternTypeUseDefinitionScope)
 
 TEST_SUITE_BEGIN("TypeInferExternTypes");
 
@@ -1235,6 +1237,193 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "extern_type_intersection_with_table_type_2")
     LUAU_CHECK_NO_ERRORS(result);
 
     CHECK_EQ("Instance & { brushes: Instance }", toString(requireTypeAtPosition({2, 18})));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_method_property_syntax_resolves_without_leak")
+{
+    // Regression test: type references inside an extern type's body (here, a generic
+    // method's own type parameter, declared using the pre-existing colon-property syntax)
+    // must resolve against the extern type's own definition scope. Before
+    // LuauExternTypeUseDefinitionScope, the per-method generic scope was created as a
+    // sibling of the (unused) extern type definition scope rather than a child of it, so
+    // TypeChecker2's location-based scope lookup could never find it, and `T` was reported
+    // as an unresolved global.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Cat with
+            meow: <T>(self: Cat, whatever: T) -> T
+        end
+    )");
+
+    CheckResult result = check(R"(
+        local c: Cat = nil :: any
+        local x = c:meow(5)
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("number", toString(requireType("x")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_method_property_syntax_still_broken_without_flag")
+{
+    // Without the fix, `T` fails to resolve while checking the definition file itself
+    // (not the code that uses Cat), so loading the definition file is where this fails.
+    ScopedFastFlag sff{FFlag::DebugLuauForceOldSolver, false};
+
+    unfreeze(getFrontend().globals.globalTypes);
+    LoadDefinitionFileResult loadResult = getFrontend().loadDefinitionFile(
+        getFrontend().globals, getFrontend().globals.globalScope, R"(
+        declare extern type Cat with
+            meow: <T>(self: Cat, whatever: T) -> T
+        end
+    )",
+        "@test",
+        /* captureComments */ false,
+        /* typecheckForAutocomplete */ false
+    );
+    freeze(getFrontend().globals.globalTypes);
+
+    CHECK(!loadResult.success);
+    REQUIRE(loadResult.module);
+    CHECK(!loadResult.module->errors.empty());
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_function_sugar_generic_method_resolves")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauExternTypeGenericMethods, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Cat with
+            function meow<T>(self, whatever: T): T
+        end
+    )");
+
+    CheckResult result = check(R"(
+        local c: Cat = nil :: any
+        local x = c:meow(5)
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("number", toString(requireType("x")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_method_multiple_params")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauExternTypeGenericMethods, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Cat with
+            function pair<T, U>(self, a: T, b: U): (T, U)
+        end
+    )");
+
+    CheckResult result = check(R"(
+        local c: Cat = nil :: any
+        local x, y = c:pair(5, "hello")
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("number", toString(requireType("x")));
+    CHECK_EQ("string", toString(requireType("y")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_method_infers_union_return_from_argument")
+{
+    // Method that takes T as a parameter and returns T | string: T should be inferred
+    // from the argument, and the call's result type should reflect the full union.
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauExternTypeGenericMethods, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type Cat with
+            function meowOrName<T>(self, whatever: T): T | string
+        end
+    )");
+
+    CheckResult result = check(R"(
+        local c: Cat = nil :: any
+        local result = c:meowOrName(5)
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+
+    TypeId resultTy = requireType("result");
+    const UnionType* ut = get<UnionType>(follow(resultTy));
+    REQUIRE_MESSAGE(ut, "Expected a union type, got " << toString(resultTy));
+
+    bool hasNumber = false;
+    bool hasString = false;
+    for (TypeId option : ut)
+    {
+        option = follow(option);
+        if (get<PrimitiveType>(option) && toString(option) == "number")
+            hasNumber = true;
+        if (get<PrimitiveType>(option) && toString(option) == "string")
+            hasString = true;
+    }
+
+    CHECK(hasNumber);
+    CHECK(hasString);
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_method_explicit_instantiation")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauExternTypeGenericMethods, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type HttpResponse with
+            function try_json<T>(self): T?
+        end
+    )");
+
+    CheckResult result = check(R"(
+        local response: HttpResponse = nil :: any
+        local data = response:try_json<<{ name: string }>>()
+    )");
+
+    LUAU_CHECK_NO_ERRORS(result);
+    CHECK_EQ("{ name: string }?", toString(requireType("data")));
+}
+
+TEST_CASE_FIXTURE(Fixture, "extern_type_generic_method_explicit_instantiation_mismatch")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauExternTypeUseDefinitionScope, true},
+        {FFlag::LuauExternTypeGenericMethods, true},
+    };
+
+    loadDefinition(R"(
+        declare extern type HttpResponse with
+            function try_json<T>(self): T?
+        end
+    )");
+
+    CheckResult result = check(R"(
+        local response: HttpResponse = nil :: any
+        local data: number = response:try_json<<string>>()
+    )");
+
+    LUAU_REQUIRE_ERRORS(result);
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.intersectionTypes.test.cpp
+++ b/tests/TypeInfer.intersectionTypes.test.cpp
@@ -13,6 +13,7 @@ LUAU_FASTFLAG(LuauCheckFunctionStatementTypes)
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauPropagateFreeTypesIntoUnionAndIntersectionBounds)
 LUAU_FASTFLAG(LuauDropUnionSubtypeReasoning)
+LUAU_FASTFLAG(LuauTruthyFalsy)
 
 TEST_SUITE_BEGIN("IntersectionTypes");
 
@@ -1513,7 +1514,10 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "narrow_intersection_nevers")
         end
     )"));
 
-    CHECK_EQ("Player & { read Character: ~((false | none)?) }", toString(requireTypeAtPosition({3, 23})));
+    if (FFlag::LuauTruthyFalsy)
+        CHECK_EQ("Player & { read Character: truthy }", toString(requireTypeAtPosition({3, 23})));
+    else
+        CHECK_EQ("Player & { read Character: ~((false | none)?) }", toString(requireTypeAtPosition({3, 23})));
 }
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "bounds_propagate_into_free_intersection_bounds")

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -19,6 +19,7 @@
 using namespace Luau;
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
+LUAU_FASTFLAG(LuauTruthyFalsy)
 
 LUAU_FASTFLAG(LuauInstantiateInSubtyping)
 LUAU_FASTFLAG(LuauFixIndexerSubtypingOrdering)
@@ -5280,11 +5281,21 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_union_type")
         end
     )");
     LUAU_REQUIRE_ERROR_COUNT(1, result);
-    CHECK_EQ(
-        "Cannot add indexer to table '{ @metatable t1, (nil & ~((false | none)?)) | {  } } where t1 = { new: <a>(a) -> { @metatable t1, (a & ~((false | none)?)) | {  "
-        "} } }'",
-        toString(result.errors[0])
-    );
+    if (FFlag::LuauTruthyFalsy)
+    {
+        CHECK_EQ(
+            "Cannot add indexer to table '{ @metatable t1, (nil & truthy) | {  } } where t1 = { new: <a>(a) -> { @metatable t1, (a & truthy) | {  } } }'",
+            toString(result.errors[0])
+        );
+    }
+    else
+    {
+        CHECK_EQ(
+            "Cannot add indexer to table '{ @metatable t1, (nil & ~((false | none)?)) | {  } } where t1 = { new: <a>(a) -> { @metatable t1, (a & ~((false | none)?)) | {  "
+            "} } }'",
+            toString(result.errors[0])
+        );
+    }
 }
 
 TEST_CASE_FIXTURE(Fixture, "function_check_constraint_too_eager")

--- a/tests/TypeInfer.typeInstantiations.test.cpp
+++ b/tests/TypeInfer.typeInstantiations.test.cpp
@@ -297,6 +297,31 @@ TEST_CASE_FIXTURE(Fixture, "not_a_function")
     }
 }
 
+TEST_CASE_FIXTURE(Fixture, "unknown_type_reports_error")
+{
+    ScopedFastFlag sffSolver{FFlag::DebugLuauForceOldSolver, false};
+
+    CheckResult result = check(R"(
+    --!strict
+    local function domeow<T>(x: T): T
+        return x
+    end
+
+    type CoinbaseTicker = {
+        product_id: string,
+        price: string,
+        side: string,
+    }
+
+    local res = domeow<<CoinbasTicker>>({price = "12", product_id = "4", side = "upside down"})
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    LUAU_REQUIRE_ERROR(result, UnknownSymbol);
+
+    CHECK_EQ("Unknown type 'CoinbasTicker'", toString(result.errors[0]));
+}
+
 TEST_CASE_FIXTURE(BuiltinsFixture, "metatable_call")
 {
     SUBCASE_BOTH_SOLVERS()

--- a/tests/conformance/types.luau
+++ b/tests/conformance/types.luau
@@ -11,6 +11,7 @@ local ignore =
 	-- what follows is a set of mismatches that hopefully eventually will go down to 0
 	"_G.require", -- need to move to Roblox type defs
 	"_G.none", -- falsy global value, declared as any
+	"_G.integer", -- WIP integer library is being replaced, type info and VM registration are out of sync
 }
 
 function verify(real, rtti, path)


### PR DESCRIPTION
Big changes, required huge changes in Analysis. You want to use mluau/luau-lsp branch with similar branch name to take advantage of these changes/fixes

Flags: LuauExternTypeGenericMethods and LuauExternTypeUseDefinitionScope

latter is the fix for method scopes on extern types incorrectly being siblings of the extern type scope and not children of the extern type scope causing analysis to be unable to find generics when traversing into and upwards from extern type declaration scope.