### PR TITLE
Rename none to nonesym and noval to none

### DIFF
--- a/Bytecode/src/BytecodeBuilder.cpp
+++ b/Bytecode/src/BytecodeBuilder.cpp
@@ -2693,7 +2693,7 @@ static const char* getBaseTypeString(uint8_t type)
         return "vector";
     case LBC_TYPE_BUFFER:
         return "buffer";
-    case LBC_TYPE_NONE:
+    case LBC_TYPE_NONESYM:
         return "none";
     case LBC_TYPE_ANY:
         return "any";

--- a/CodeGen/src/BytecodeAnalysis.cpp
+++ b/CodeGen/src/BytecodeAnalysis.cpp
@@ -223,7 +223,7 @@ static uint8_t getBytecodeConstantTag(Proto* proto, unsigned ki)
         return LBC_TYPE_INTEGER;
     case LUA_TVECTOR:
         return LBC_TYPE_VECTOR;
-    case LUA_TNONE:
+    case LUA_TNONESYM:
         return LBC_TYPE_NONE;
     case LUA_TSTRING:
         return LBC_TYPE_STRING;

--- a/CodeGen/src/BytecodeAnalysis.cpp
+++ b/CodeGen/src/BytecodeAnalysis.cpp
@@ -224,7 +224,7 @@ static uint8_t getBytecodeConstantTag(Proto* proto, unsigned ki)
     case LUA_TVECTOR:
         return LBC_TYPE_VECTOR;
     case LUA_TNONESYM:
-        return LBC_TYPE_NONE;
+        return LBC_TYPE_NONESYM;
     case LUA_TSTRING:
         return LBC_TYPE_STRING;
     case LUA_TTABLE:

--- a/CodeGen/src/IrBuilder.cpp
+++ b/CodeGen/src/IrBuilder.cpp
@@ -106,7 +106,7 @@ static void buildArgumentTypeChecks(IrBuilder& build, IrOp entry)
             build.inst(IrCmd::CHECK_TAG, load, build.constTag(LUA_TBUFFER), build.vmExit(kVmExitEntryGuardPc));
             break;
         case LBC_TYPE_NONE:
-            build.inst(IrCmd::CHECK_TAG, load, build.constTag(LUA_TNONE), build.vmExit(kVmExitEntryGuardPc));
+            build.inst(IrCmd::CHECK_TAG, load, build.constTag(LUA_TNONESYM), build.vmExit(kVmExitEntryGuardPc));
             break;
         default:
             if (tag >= LBC_TYPE_TAGGED_USERDATA_BASE && tag < LBC_TYPE_TAGGED_USERDATA_END)

--- a/CodeGen/src/IrBuilder.cpp
+++ b/CodeGen/src/IrBuilder.cpp
@@ -105,7 +105,7 @@ static void buildArgumentTypeChecks(IrBuilder& build, IrOp entry)
         case LBC_TYPE_BUFFER:
             build.inst(IrCmd::CHECK_TAG, load, build.constTag(LUA_TBUFFER), build.vmExit(kVmExitEntryGuardPc));
             break;
-        case LBC_TYPE_NONE:
+        case LBC_TYPE_NONESYM:
             build.inst(IrCmd::CHECK_TAG, load, build.constTag(LUA_TNONESYM), build.vmExit(kVmExitEntryGuardPc));
             break;
         default:

--- a/CodeGen/src/IrDump.cpp
+++ b/CodeGen/src/IrDump.cpp
@@ -65,7 +65,7 @@ static const char* getTagName(uint8_t tag)
         return "tnumber";
     case LUA_TVECTOR:
         return "tvector";
-    case LUA_TNONE:
+    case LUA_TNONESYM:
         return "tnone";
     case LUA_TSTRING:
         return "tstring";

--- a/CodeGen/src/IrDump.cpp
+++ b/CodeGen/src/IrDump.cpp
@@ -66,7 +66,7 @@ static const char* getTagName(uint8_t tag)
     case LUA_TVECTOR:
         return "tvector";
     case LUA_TNONESYM:
-        return "tnone";
+        return "tnonesym";
     case LUA_TSTRING:
         return "tstring";
     case LUA_TTABLE:

--- a/CodeGen/src/IrDump.cpp
+++ b/CodeGen/src/IrDump.cpp
@@ -812,7 +812,7 @@ const char* getBytecodeTypeName(uint8_t type, const char* const* userdataTypes)
         return "vector";
     case LBC_TYPE_BUFFER:
         return "buffer";
-    case LBC_TYPE_NONE:
+    case LBC_TYPE_NONESYM:
         return "none";
     case LBC_TYPE_ANY:
         return "any";

--- a/CodeGen/src/IrUtils.cpp
+++ b/CodeGen/src/IrUtils.cpp
@@ -1939,7 +1939,7 @@ std::optional<uint8_t> tryGetLuauTagForBcType(uint8_t bcType, bool ignoreOptiona
     case LBC_TYPE_BUFFER:
         return LUA_TBUFFER;
     case LBC_TYPE_NONE:
-        return LUA_TNONE;
+        return LUA_TNONESYM;
     default:
         if (bcType >= LBC_TYPE_TAGGED_USERDATA_BASE && bcType < LBC_TYPE_TAGGED_USERDATA_END)
             return LUA_TUSERDATA;

--- a/CodeGen/src/IrUtils.cpp
+++ b/CodeGen/src/IrUtils.cpp
@@ -1938,7 +1938,7 @@ std::optional<uint8_t> tryGetLuauTagForBcType(uint8_t bcType, bool ignoreOptiona
         return LUA_TVECTOR;
     case LBC_TYPE_BUFFER:
         return LUA_TBUFFER;
-    case LBC_TYPE_NONE:
+    case LBC_TYPE_NONESYM:
         return LUA_TNONESYM;
     default:
         if (bcType >= LBC_TYPE_TAGGED_USERDATA_BASE && bcType < LBC_TYPE_TAGGED_USERDATA_END)

--- a/Common/include/Luau/Bytecode.h
+++ b/Common/include/Luau/Bytecode.h
@@ -537,7 +537,7 @@ enum LuauBytecodeType
     LBC_TYPE_VECTOR,
     LBC_TYPE_BUFFER,
     LBC_TYPE_INTEGER,
-    LBC_TYPE_NONE,
+    LBC_TYPE_NONESYM,
 
     LBC_TYPE_ANY = 15,
 

--- a/Compiler/src/Types.cpp
+++ b/Compiler/src/Types.cpp
@@ -36,7 +36,7 @@ static LuauBytecodeType getPrimitiveType(AstName name)
     else if (name == "vector")
         return LBC_TYPE_VECTOR;
     else if (name == "none")
-        return LBC_TYPE_NONE;
+        return LBC_TYPE_NONESYM;
     else if (name == "any" || name == "unknown")
         return LBC_TYPE_ANY;
     else

--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -66,7 +66,7 @@ typedef void (*lua_Destructor)(lua_State* L, void* userdata);
 /*
 ** basic types
 */
-#define LUA_TNOVAL (-1)
+#define LUA_TNONE (-1)
 
 /*
  * WARNING: if you change the order of this enumeration,
@@ -82,7 +82,7 @@ enum lua_Type
     LUA_TNUMBER,
     LUA_TINTEGER,
     LUA_TVECTOR,
-    LUA_TNONE,
+    LUA_TNONESYM,
 
     LUA_TSTRING, // all types above this must be value types, all types below this must be GC types - see iscollectable
 
@@ -187,7 +187,7 @@ LUA_API const void* lua_topointer(lua_State* L, int idx);
 ** push functions (C -> stack)
 */
 LUA_API void lua_pushnil(lua_State* L);
-LUA_API void lua_pushnone(lua_State* L);
+LUA_API void lua_pushnonesym(lua_State* L);
 LUA_API void lua_pushnumber(lua_State* L, double n);
 LUA_API void lua_pushinteger(lua_State* L, int n);
 LUA_API void lua_pushinteger64(lua_State* L, int64_t n);
@@ -449,6 +449,7 @@ LUA_API void lua_unref(lua_State* L, int ref);
 #define lua_isthread(L, n) (lua_type(L, (n)) == LUA_TTHREAD)
 #define lua_isbuffer(L, n) (lua_type(L, (n)) == LUA_TBUFFER)
 #define lua_isnone(L, n) (lua_type(L, (n)) == LUA_TNONE)
+#define lua_isnonesym(L, n) (lua_type(L, (n)) == LUA_TNONESYM)
 #define lua_isnoneornil(L, n) (lua_type(L, (n)) <= LUA_TNIL)
 #define lua_isclass(L, n) (lua_type(L, (n)) == LUA_TCLASS)
 #define lua_isobject(L, n) (lua_type(L, (n)) == LUA_TOBJECT)

--- a/VM/src/lapi.cpp
+++ b/VM/src/lapi.cpp
@@ -344,14 +344,15 @@ void lua_pushvalue(lua_State* L, int idx)
 int lua_type(lua_State* L, int idx)
 {
     StkId o = index2addr(L, idx);
-    return (o == luaO_nilobject) ? LUA_TNOVAL : ttype(o);
+    return (o == luaO_nilobject) ? LUA_TNONE : ttype(o);
 }
 
 const char* lua_typename(lua_State* L, int t)
 {
-    api_check(L, t >= LUA_TNOVAL && t < LUA_T_COUNT);
-
-    return (t == LUA_TNOVAL) ? "no value" : luaT_typenames[t];
+    api_check(L, t >= LUA_TNONE && t < LUA_T_COUNT);
+    if (t == LUA_TNONE)
+        return "no value";
+    return luaT_typenames[t];
 }
 
 int lua_iscfunction(lua_State* L, int idx)
@@ -688,11 +689,11 @@ void lua_pushnil(lua_State* L)
     api_incr_top(L);
 }
 
-void lua_pushnone(lua_State* L)
+void lua_pushnonesym(lua_State* L)
 {
     LUAU_ASSERT(FFlag::LuauNonePrimitive);
     ensure_stack(L, 1);
-    setnonevalue(L->top);
+    setnonesymvalue(L->top);
     api_incr_top(L);
 }
 

--- a/VM/src/laux.cpp
+++ b/VM/src/laux.cpp
@@ -180,7 +180,7 @@ void luaL_checktype(lua_State* L, int narg, int t)
 
 void luaL_checkany(lua_State* L, int narg)
 {
-    if (lua_type(L, narg) == LUA_TNOVAL)
+    if (lua_type(L, narg) == LUA_TNONE)
         luaL_error(L, "missing argument #%d", narg);
 }
 
@@ -597,7 +597,7 @@ void luaL_addvalueany(luaL_Strbuf* B, int idx)
 
     switch (lua_type(L, idx))
     {
-    case LUA_TNOVAL:
+    case LUA_TNONE:
     {
         LUAU_ASSERT(!"expected value");
         break;
@@ -605,7 +605,7 @@ void luaL_addvalueany(luaL_Strbuf* B, int idx)
     case LUA_TNIL:
         luaL_addstring(B, "nil");
         break;
-    case LUA_TNONE:
+    case LUA_TNONESYM:
         luaL_addstring(B, "none");
         break;
     case LUA_TBOOLEAN:
@@ -696,7 +696,7 @@ const char* luaL_tolstring(lua_State* L, int idx, size_t* len)
     case LUA_TNIL:
         lua_pushliteral(L, "nil");
         break;
-    case LUA_TNONE:
+    case LUA_TNONESYM:
         lua_pushliteral(L, "none");
         break;
     case LUA_TBOOLEAN:

--- a/VM/src/lbaselib.cpp
+++ b/VM/src/lbaselib.cpp
@@ -447,7 +447,7 @@ static int luaB_tostring(lua_State* L)
 static int luaB_newproxy(lua_State* L)
 {
     int t = lua_type(L, 1);
-    luaL_argexpected(L, t == LUA_TNOVAL || t == LUA_TNIL || t == LUA_TBOOLEAN, 1, "nil or boolean");
+    luaL_argexpected(L, t == LUA_TNONE || t == LUA_TNIL || t == LUA_TBOOLEAN, 1, "nil or boolean");
 
     bool needsmt = lua_toboolean(L, 1);
 
@@ -505,7 +505,7 @@ int luaopen_base(lua_State* L)
 
     if (FFlag::LuauNonePrimitive)
     {
-        lua_pushnone(L);
+        lua_pushnonesym(L);
         lua_setglobal(L, "none");
     }
 

--- a/VM/src/lbuiltins.cpp
+++ b/VM/src/lbuiltins.cpp
@@ -1302,9 +1302,9 @@ static int luauF_tostring(lua_State* L, StkId res, TValue* arg0, int nresults, S
             setsvalue(L, res, s);
             return 1;
         }
-        case LUA_TNONE:
+        case LUA_TNONESYM:
         {
-            TString* s = L->global->ttname[LUA_TNONE];
+            TString* s = L->global->ttname[LUA_TNONESYM];
             setsvalue(L, res, s);
             return 1;
         }

--- a/VM/src/lgcdebug.cpp
+++ b/VM/src/lgcdebug.cpp
@@ -936,7 +936,7 @@ static void enumproto(EnumContext* ctx, Proto* p)
     {
         size_t nativesize = ctx->L->global->ecb.getmemorysize(ctx->L, p);
 
-        ctx->node(ctx->context, p->execdata, uint8_t(LUA_TNONE), p->memcat, nativesize, NULL);
+        ctx->node(ctx->context, p->execdata, uint8_t(LUA_TNONESYM), p->memcat, nativesize, NULL);
         ctx->edge(ctx->context, enumtopointer(obj2gco(p)), p->execdata, "[native]");
     }
 

--- a/VM/src/lobject.cpp
+++ b/VM/src/lobject.cpp
@@ -41,7 +41,7 @@ int luaO_rawequalObj(const TValue* t1, const TValue* t2)
         switch (ttype(t1))
         {
         case LUA_TNIL:
-        case LUA_TNONE:
+        case LUA_TNONESYM:
             return 1;
         case LUA_TNUMBER:
             return luai_numeq(nvalue(t1), nvalue(t2));
@@ -67,7 +67,7 @@ int luaO_rawequalKey(const TKey* t1, const TValue* t2)
         switch (ttype(t1))
         {
         case LUA_TNIL:
-        case LUA_TNONE:
+        case LUA_TNONESYM:
             return 1;
         case LUA_TNUMBER:
             return luai_numeq(nvalue(t1), nvalue(t2));

--- a/VM/src/lobject.h
+++ b/VM/src/lobject.h
@@ -52,7 +52,7 @@ typedef struct lua_TValue
 
 // Macros to test type
 #define ttisnil(o) (ttype(o) == LUA_TNIL)
-#define ttisnone(o) (ttype(o) == LUA_TNONE)
+#define ttisnonesym(o) (ttype(o) == LUA_TNONESYM)
 #define ttisnumber(o) (ttype(o) == LUA_TNUMBER)
 #define ttisinteger(o) (ttype(o) == LUA_TINTEGER)
 #define ttisstring(o) (ttype(o) == LUA_TSTRING)
@@ -86,7 +86,7 @@ typedef struct lua_TValue
 #define classvalue(o) check_exp(ttisclass(o), &(o)->value.gc->lclass)
 #define objectvalue(o) check_exp(ttisobject(o), &(o)->value.gc->lobject)
 
-#define l_isfalse(o) (ttisnil(o) || (ttisboolean(o) && bvalue(o) == 0) || ttisnone(o))
+#define l_isfalse(o) (ttisnil(o) || (ttisboolean(o) && bvalue(o) == 0) || ttisnonesym(o))
 
 #define lightuserdatatag(o) check_exp(ttislightuserdata(o), (o)->extra[0])
 
@@ -102,7 +102,7 @@ typedef struct lua_TValue
 
 // Macros to set values
 #define setnilvalue(obj) ((obj)->tt = LUA_TNIL)
-#define setnonevalue(obj) ((obj)->tt = LUA_TNONE)
+#define setnonesymvalue(obj) ((obj)->tt = LUA_TNONESYM)
 
 #define setnvalue(obj, x) \
     { \

--- a/VM/src/ltable.cpp
+++ b/VM/src/ltable.cpp
@@ -170,7 +170,7 @@ static LuaNode* mainposition(const LuaTable* t, const TValue* key)
         return hashstr(t, tsvalue(key));
     case LUA_TBOOLEAN:
         return hashboolean(t, bvalue(key));
-    case LUA_TNONE:
+    case LUA_TNONESYM:
         return hashnone(t);
     case LUA_TLIGHTUSERDATA:
         return hashpointer(t, pvalue(key));

--- a/VM/src/lvmexecute.cpp
+++ b/VM/src/lvmexecute.cpp
@@ -1356,7 +1356,7 @@ reentry:
                     switch (ttype(ra))
                     {
                     case LUA_TNIL:
-                    case LUA_TNONE:
+                    case LUA_TNONESYM:
                         pc += LUAU_INSN_D(insn);
                         VM_ASSERT_PC(pc);
                         VM_NEXT();
@@ -1490,7 +1490,7 @@ reentry:
                     switch (ttype(ra))
                     {
                     case LUA_TNIL:
-                    case LUA_TNONE:
+                    case LUA_TNONESYM:
                         pc += 1;
                         VM_ASSERT_PC(pc);
                         VM_NEXT();

--- a/rfcx/none.md
+++ b/rfcx/none.md
@@ -85,17 +85,16 @@ Unlike `nil`, storing `none` in a table preserves the key-value pair:
 The C API is expanded with the following definitions and functions:
 
 ```c
-#define LUA_TNONE 6
+#define LUA_TNONESYM 6
 
-LUA_API int lua_isnone(lua_State* L, int idx);
-LUA_API void lua_pushnone(lua_State* L);
+LUA_API int lua_isnonesym(lua_State* L, int idx);
+LUA_API void lua_pushnonesym(lua_State* L);
 ```
 
-- `lua_type(L, idx)` returns `LUA_TNONE` for `none` values.
-- `lua_typename(L, LUA_TNONE)` returns `"none"`.
-- `lua_toboolean(L, idx)` returns `0` when the value at `idx` has type `LUA_TNONE`.
-- `lua_isnone(L, idx)` returns `1` if the value at `idx` is `LUA_TNONE`, and `0` otherwise.
-*(Note: To accommodate `LUA_TNONE` as tag 6, the API constant for an invalid/out-of-bounds stack index `-1` is defined as `LUA_TNOVAL`).*
+- `lua_type(L, idx)` returns `LUA_TNONESYM` for `none` values.
+- `lua_typename(L, LUA_TNONESYM)` returns `"none"`.
+- `lua_toboolean(L, idx)` returns `0` when the value at `idx` has type `LUA_TNONESYM`.
+- `lua_isnonesym(L, idx)` returns `1` if the value at `idx` is `LUA_TNONESYM`, and `0` otherwise.
 
 ### Standard Library
 

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -2930,7 +2930,7 @@ TEST_CASE("ApiType")
     CHECK(lua_type(L, 1) == LUA_TNUMBER);
 
     CHECK(strcmp(luaL_typename(L, 2), "no value") == 0);
-    CHECK(lua_type(L, 2) == LUA_TNOVAL);
+    CHECK(lua_type(L, 2) == LUA_TNONE);
     CHECK(strcmp(lua_typename(L, lua_type(L, 2)), "no value") == 0);
 
     lua_newuserdata(L, 0);


### PR DESCRIPTION
Bug fix to rename none to nonesym to avoid conflicts with lua's existing concept of none in the stack side

Credits to utrain and @deviaze for naming