### PR TITLE
Fix memory leak for external buffers

### DIFF
--- a/VM/src/lbuffer.cpp
+++ b/VM/src/lbuffer.cpp
@@ -5,6 +5,7 @@
 #include "lmem.h"
 
 #include "lstate.h"
+#include "ldo.h"
 #include <string.h>
 
 Buffer* luaB_newbuffer(lua_State* L, size_t s)
@@ -26,9 +27,32 @@ Buffer* luaB_newexternalbuffer(lua_State* L, size_t s, void* data, void* userdat
 {
     LUAU_ASSERT(mode == 1 || mode == 2);
     if (s > MAX_BUFFER_SIZE)
+    {
+        if (free_cb)
+            free_cb(L, data, s, userdata);
         luaM_toobig(L);
+    }
 
-    Buffer* b = luaM_newgco(L, Buffer, offsetof(Buffer, inline_data), L->activememcat);
+    struct AllocContext
+    {
+        Buffer* b = nullptr;
+
+        static void run(lua_State* L, void* ud)
+        {
+            AllocContext* ctx = static_cast<AllocContext*>(ud);
+            ctx->b = luaM_newgco(L, Buffer, offsetof(Buffer, inline_data), L->activememcat);
+        }
+    } ctx;
+
+    int status = luaD_rawrunprotected(L, &AllocContext::run, &ctx);
+    if (status != 0)
+    {
+        if (free_cb)
+            free_cb(L, data, s, userdata);
+        luaD_throw(L, status);
+    }
+
+    Buffer* b = ctx.b;
     luaC_init(L, b, LUA_TBUFFER);
     b->len = unsigned(s);
     b->mode = mode;

--- a/tests/ExternalBuffer.test.cpp
+++ b/tests/ExternalBuffer.test.cpp
@@ -49,6 +49,28 @@ static int dostring_ncg(lua_State* L, const char* code)
 
 TEST_SUITE_BEGIN("ExternalBuffers");
 
+static int too_big_external_buffer_cb(lua_State* L)
+{
+    size_t len = (1 << 30) + 1; // MAX_BUFFER_SIZE + 1
+    int test_userdata = 42;
+    lua_newexternalbuffer(L, len, nullptr, &test_userdata, test_buffer_free_cb, LUA_BHOST_MUTABLE);
+    return 0;
+}
+
+TEST_CASE("ExternalBufferTooBig")
+{
+    ScopedFastFlag sff{FFlag::LuauExternallyManagedBuffers, true};
+    std::unique_ptr<lua_State, void (*)(lua_State*)> state(luaL_newstate(), lua_close);
+    lua_State* L = state.get();
+    
+    s_externalBufferFreeCount = 0;
+    
+    int result = lua_cpcall(L, too_big_external_buffer_cb, NULL);
+    CHECK(result == LUA_ERRRUN);
+    CHECK(s_externalBufferFreeCount == 1);
+}
+
+
 TEST_CASE("ExternalBufferMutable")
 {
     ScopedFastFlag sff{FFlag::LuauExternallyManagedBuffers, true};


### PR DESCRIPTION
Like external strings case, luaM_newgco can OOM in which case `free_cb` needs to be called to properly free the external buffer otherwise a memory leak will result. Unlike external strings, external buffers can be quite big in size making this a more serious problem