### PR TITLE
Add `lua_findunuseduserdatatag` to C API extensions

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,3 +6,7 @@
 - LuauDefaultArguments: @Bottersnike
 - LuauNonePrimitive: @cheesycod
 - LuauExternalString (and DebugLuauAllowNonNullTerminatedStrings for tests): @cheesycod
+
+## Other
+
+- `lua_findunuseduserdatatag`, `lua_findunusedlightuserdatatag`: @PhoenixWhitefire

--- a/VM/include/lapix.h
+++ b/VM/include/lapix.h
@@ -1,0 +1,14 @@
+// This file is part of the Luau programming language and is licensed under MIT License; see LICENSE.txt for details
+#pragma once
+#include "lua.h"
+
+LUA_API const void* lua_getmetatablepointer(lua_State* L, int objindex);
+LUA_API const char* lua_gcstatename(int state);
+LUA_API int64_t lua_gcallocationrate(lua_State* L);
+LUA_API void lua_gcdump(lua_State* L, void* file, const char* (*categoryName)(lua_State* L, uint8_t memcat));
+LUA_API int luau_setfflag(const char* name, int value);
+LUA_API int luau_getfflag(const char* name);
+
+// Finds a userdata tag for which neither a metatable nor destructor is associated.
+// Returns -1 if none were found.
+LUA_API int lua_findunuseduserdatatag(lua_State* L);

--- a/VM/include/lapix.h
+++ b/VM/include/lapix.h
@@ -12,3 +12,6 @@ LUA_API int luau_getfflag(const char* name);
 // Finds a userdata tag for which neither a metatable nor destructor is associated.
 // Returns -1 if none were found.
 LUA_API int lua_findunuseduserdatatag(lua_State* L);
+// Finds a light userdata tag that has not been associated with a name.
+// Returns -1 if none were found.
+LUA_API int lua_findunusedlightuserdatatag(lua_State* L);

--- a/VM/src/lapix.cpp
+++ b/VM/src/lapix.cpp
@@ -72,7 +72,20 @@ int lua_findunuseduserdatatag(lua_State *L)
 
     for (int tag = 0; tag < LUA_UTAG_LIMIT; tag++)
     {
-        if (!global->udatamt[tag] && !global->udatagc[tag])
+        if (!global->udatamt[tag] && !global->udatagc[tag] && !global->udatadirectfields[tag])
+            return tag;
+    }
+
+    return -1;
+}
+
+int lua_findunusedlightuserdatatag(lua_State *L)
+{
+    global_State* global = L->global;
+
+    for (int tag = 0; tag < LUA_LUTAG_LIMIT; tag++)
+    {
+        if (!global->lightuserdataname[tag])
             return tag;
     }
 

--- a/VM/src/lapix.cpp
+++ b/VM/src/lapix.cpp
@@ -1,0 +1,80 @@
+#include "lapix.h"
+#include "lapi.h"
+#include "lgc.h"
+#include "lobject.h"
+#include "lstate.h"
+#include "Luau/Common.h"
+
+#include <stdexcept>
+#include <string.h>
+
+using namespace std;
+
+LUA_API const void* lua_getmetatablepointer(lua_State* L, int objindex)
+{
+    const TValue* obj = luaA_toobject(L, objindex);
+    if (!obj)
+        return NULL;
+
+    switch (ttype(obj))
+    {
+    case LUA_TTABLE:
+        return hvalue(obj)->metatable;
+    case LUA_TUSERDATA:
+        return uvalue(obj)->metatable;
+    default:
+        return NULL;
+    }
+}
+
+LUA_API const char* lua_gcstatename(int state)
+{
+    return luaC_statename(state);
+}
+
+LUA_API int64_t lua_gcallocationrate(lua_State* L) {
+    return luaC_allocationrate(L);
+}
+
+LUA_API void lua_gcdump(lua_State* L, void* file, const char* (*categoryName)(lua_State* L, uint8_t memcat))
+{
+    luaC_dump(L, file, categoryName);
+}
+
+LUA_API int luau_setfflag(const char* name, int value)
+{
+    for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
+    {
+        if (strcmp(flag->name, name) == 0)
+        {
+            flag->value = value;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+LUA_API int luau_getfflag(const char* name)
+{
+    for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
+    {
+        if (strcmp(flag->name, name) == 0)
+        {
+            return flag->value ? 1 : 0;
+        }
+    }
+    return -1;
+}
+
+int lua_findunuseduserdatatag(lua_State *L)
+{
+    global_State* global = L->global;
+
+    for (int tag = 0; tag < LUA_UTAG_LIMIT; tag++)
+    {
+        if (!global->udatamt[tag] && !global->udatagc[tag])
+            return tag;
+    }
+
+    return -1;
+}

--- a/rfcx/api-findunusedtags.md
+++ b/rfcx/api-findunusedtags.md
@@ -21,6 +21,6 @@ then it will return `-1`.
 
 ### `int lua_findunusedlightuserdatatag(lua_State* L)`
 
-This fucntion will find and return a light userdata tag that has not been associated with a name.
+This function will find and return a light userdata tag that has not been associated with a name.
 If it cannot find any available tags (tags are restricted to the range `[0..LUA_LUTAG_LIMIT]`),
 then it will return `-1`.

--- a/rfcx/api-findunusedtags.md
+++ b/rfcx/api-findunusedtags.md
@@ -3,7 +3,7 @@
 Status: Implemented
 
 ## Summary
-Implement functions for finding unused userdata and light userdata tags to reduce bookkeeping on the host's side.
+Implement functions for finding unused userdata and light userdata tags.
 
 ## Motivation
 It is currently not possible for embedders to know what tags are available for use through just the existing public C API.

--- a/rfcx/api-findunusedtags.md
+++ b/rfcx/api-findunusedtags.md
@@ -1,0 +1,26 @@
+# `lua_findunuseduserdatatag`, `lua_findunusedlightuserdatatag`
+
+Status: Implemented
+
+## Summary
+Implement functions for finding unused userdata and light userdata tags to reduce bookkeeping on the host's side.
+
+## Motivation
+It is currently not possible for embedders to know what tags are available for use through just the existing public C API.
+Embedders may sometimes want to query for an available tag without having to keep track of every tag by themselves.
+
+## Design
+
+Two new members will be added to the C API: `lua_findunuseduserdatatag`, and `lua_findunusedlightuserdatatag`.
+
+### `int lua_findunuseduserdatatag(lua_State* L)`
+
+This function will find and return a userdata tag that has not been used for any other purpose (userdata metatables, userdata destructors, or userdata direct field access).
+If it cannot find any available tags (tags are restricted to the range `[0..LUA_UTAG_LIMIT]`),
+then it will return `-1`.
+
+### `int lua_findunusedlightuserdatatag(lua_State* L)`
+
+This fucntion will find and return a light userdata tag that has not been associated with a name.
+If it cannot find any available tags (tags are restricted to the range `[0..LUA_LUTAG_LIMIT]`),
+then it will return `-1`.

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -2,6 +2,7 @@
 #include "Luau/Common.h"
 #include "Luau/Type.h"
 #include "lua.h"
+#include "lapix.h"
 #include "lualib.h"
 #include "luacode.h"
 #include "luacodegen.h"
@@ -66,11 +67,15 @@ LUAU_FASTFLAG(LuauCodegenFixBufferLenCheck)
 LUAU_FASTFLAG(LuauYieldIter2)
 LUAU_FASTFLAG(LuauCustomYieldablePcalls)
 LUAU_FASTFLAG(DebugLuauUserDefinedClassesRuntime)
+LUAU_FASTFLAG(LuauExportValueSyntax)
+LUAU_FASTFLAG(LuauExportedClassIsNilWorkaround)
 LUAU_FASTFLAG(LuauAutoStack)
 LUAU_FASTFLAG(LuauUdataMetatablePinned)
 LUAU_DYNAMIC_FASTFLAG(LuauGcTableStepFix)
 LUAU_FASTFLAG(LuauCodegenFixTwoResA64Builtin)
 LUAU_FASTFLAG(LuauMathRoundNegZero)
+LUAU_FASTFLAG(LuauDefaultArguments)
+LUAU_FASTFLAG(LuauNonePrimitive)
 
 #ifndef LUAU_CONFORMANCE_SOURCE_DIR
 // Walks up from the current directory looking for the Client folder,
@@ -1908,6 +1913,10 @@ static void populateRTTI(lua_State* L, Luau::TypeId type)
             lua_pushstring(L, "buffer");
             break;
 
+        case Luau::PrimitiveType::NoneType:
+            lua_pushstring(L, "none");
+            break;
+
         default:
             LUAU_ASSERT(!"Unknown primitive type");
         }
@@ -1954,6 +1963,7 @@ static void populateRTTI(lua_State* L, Luau::TypeId type)
 TEST_CASE("Types")
 {
     ScopedFastFlag integerType{FFlag::LuauIntegerType2, true};
+    ScopedFastFlag nonePrimitive{FFlag::LuauNonePrimitive, true};
 
     runConformance(
         "types.luau",
@@ -2360,7 +2370,7 @@ TEST_CASE("Reference")
     lua_newuserdatadtor(
         L,
         0,
-        [](void*)
+        [](lua_State*, void* data)
         {
             dtorhits++;
         }
@@ -2368,7 +2378,7 @@ TEST_CASE("Reference")
     lua_newuserdatadtor(
         L,
         0,
-        [](void*)
+        [](lua_State*, void* data)
         {
             dtorhits++;
         }
@@ -2406,7 +2416,7 @@ TEST_CASE("NewUserdataOverflow")
         [](lua_State* L1)
         {
             // The following userdata request might cause an overflow.
-            lua_newuserdatadtor(L1, SIZE_MAX, [](void* d) {});
+            lua_newuserdatadtor(L1, SIZE_MAX, [](lua_State*, void* d) {});
             // The overflow might segfault in the following call.
             lua_getmetatable(L1, -1);
             return 0;
@@ -3543,7 +3553,7 @@ TEST_CASE("UserdataApi")
     void* ud3 = lua_newuserdatadtor(
         L,
         4,
-        [](void* data)
+        [](lua_State*, void* data)
         {
             dtorhits += *(int*)data;
         }
@@ -3552,7 +3562,7 @@ TEST_CASE("UserdataApi")
     void* ud4 = lua_newuserdatadtor(
         L,
         1,
-        [](void* data)
+        [](lua_State*, void* data)
         {
             dtorhits += *(char*)data;
         }
@@ -3632,7 +3642,7 @@ TEST_CASE("UserdataAlignment")
 
         for (int i = 0; i < 10; i++)
         {
-            void* data = lua_newuserdatadtor(L, size, [](void*) {});
+            void* data = lua_newuserdatadtor(L, size, [](lua_State*, void* data) {});
             LUAU_ASSERT(uintptr_t(data) % 16 == 0);
             lua_pop(L, 1);
         }
@@ -4235,6 +4245,18 @@ TEST_CASE("Classes")
     runConformance("classes.luau");
 }
 
+TEST_CASE("ExportedClasses")
+{
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauUserDefinedClasses, true},
+        {FFlag::DebugLuauUserDefinedClassesRuntime, true},
+        {FFlag::LuauExportValueSyntax, true},
+        {FFlag::LuauExportedClassIsNilWorkaround, true},
+    };
+
+    runConformance("exportclasses.luau");
+}
+
 [[nodiscard]] static std::string makeHugeFunctionSource()
 {
     std::string source;
@@ -4758,6 +4780,33 @@ TEST_CASE("CodegenRandomizeFunctionalCorrectness")
     REQUIRE_MESSAGE(callResult == 0, lua_tostring(L, -1));
 
     CHECK(lua_tonumber(L, -1) == 42.0);
+}
+
+TEST_CASE("DefaultArguments")
+{
+    ScopedFastFlag sff{FFlag::LuauDefaultArguments, true};
+
+    runConformance("defaultarg.luau");
+}
+
+TEST_CASE("None")
+{
+    ScopedFastFlag sff{FFlag::LuauNonePrimitive, true};
+
+    runConformance("none.luau");
+}
+
+TEST_CASE("lua_findunuseduserdatatag")
+{
+    StateRef globalState(luaL_newstate(), lua_close);
+    lua_State* L = globalState.get();
+
+    lua_createtable(L, 0, 0);
+    lua_setuserdatametatable(L, 0);
+    lua_setuserdatadtor(L, 1, [](lua_State*, void*){});
+
+    int available = lua_findunuseduserdatatag(L);
+    CHECK_EQ(available, 2);
 }
 
 TEST_SUITE_END();

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -76,6 +76,7 @@ LUAU_FASTFLAG(LuauCodegenFixTwoResA64Builtin)
 LUAU_FASTFLAG(LuauMathRoundNegZero)
 LUAU_FASTFLAG(LuauDefaultArguments)
 LUAU_FASTFLAG(LuauNonePrimitive)
+LUAU_FASTFLAG(LuauDirectFieldGet)
 
 #ifndef LUAU_CONFORMANCE_SOURCE_DIR
 // Walks up from the current directory looking for the Client folder,
@@ -4798,15 +4799,29 @@ TEST_CASE("None")
 
 TEST_CASE("lua_findunuseduserdatatag")
 {
+    ScopedFastFlag directFieldGet{FFlag::LuauDirectFieldGet, true};
+
     StateRef globalState(luaL_newstate(), lua_close);
     lua_State* L = globalState.get();
 
     lua_createtable(L, 0, 0);
     lua_setuserdatametatable(L, 0);
     lua_setuserdatadtor(L, 1, [](lua_State*, void*){});
+    lua_registeruserdatadirectfieldget(L, 2, "hina", [](void*, void*){});
 
     int available = lua_findunuseduserdatatag(L);
-    CHECK_EQ(available, 2);
+    CHECK_EQ(available, 3);
+}
+
+TEST_CASE("lua_findlightuserdatatag")
+{
+    StateRef globalState(luaL_newstate(), lua_close);
+    lua_State* L = globalState.get();
+
+    lua_setlightuserdataname(L, 0, "ferris");
+
+    int available = lua_findunusedlightuserdatatag(L);
+    CHECK_EQ(available, 1);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Adds `lua_findunuseduserdatatag`. Returns a tag which is not associated with a userdata metatable or destructor, or `-1` if none could be found.