### PR TITLE
Luau/type error message improvements

### DIFF
--- a/Analysis/include/Luau/Subtyping.h
+++ b/Analysis/include/Luau/Subtyping.h
@@ -40,11 +40,11 @@ struct SubtypingReasoning
     // The path, relative to the _root supertype_, where subtyping failed.
     Path superPath;
     SubtypingVariance variance = SubtypingVariance::Covariant;
-    // Set when the failure is due to a property modifier mismatch (e.g. the
+    // Set when the failure is due to a property or indexer modifier mismatch (e.g. the
     // sub property is read-only or write-only but the super property requires
     // read-write). In this case the leaf types at the path ends are the same,
     // so a plain "X is not a subtype of X" message would be misleading.
-    bool isPropertyModifierViolation = false;
+    bool isAccessModifierViolation = false;
 
     bool operator==(const SubtypingReasoning& other) const;
 };
@@ -142,7 +142,7 @@ struct SubtypingResult
     SubtypingResult& withSuperPath(TypePath::Path path);
     SubtypingResult& withErrors(ErrorVec& err);
     SubtypingResult& withError(TypeError err);
-    SubtypingResult& withPropertyModifierViolation();
+    SubtypingResult& withAccessModifierViolation();
 
     SubtypingResult& withAssumedConstraint(ConstraintV constraint);
 

--- a/Analysis/src/Error.cpp
+++ b/Analysis/src/Error.cpp
@@ -496,22 +496,19 @@ struct ErrorConverter
 
     std::string operator()(const Luau::MissingProperties& e) const
     {
-        std::string s = "Table type '" + toString(e.subType) + "' not compatible with type '" + toString(e.superType) + "' because the former";
-
+        std::string s;
+        std::string afterFieldList;
+        std::string pluralSuffix = e.properties.size() > 1 ? "s " : " ";
         switch (e.context)
         {
         case MissingProperties::Missing:
-            s += " is missing field";
+            s += "required field" + pluralSuffix;
+            afterFieldList = " not";
             break;
         case MissingProperties::Extra:
-            s += " has extra field";
+            s += "extra field" + pluralSuffix;
             break;
         }
-
-        if (e.properties.size() > 1)
-            s += "s";
-
-        s += " ";
 
         for (size_t i = 0; i < e.properties.size(); ++i)
         {
@@ -523,6 +520,8 @@ struct ErrorConverter
 
             s += "'" + e.properties[i] + "'";
         }
+
+        s += afterFieldList + " found in type '" + toString(e.subType) + "' from expected type '" + toString(e.superType) + "'";
 
         return s;
     }

--- a/Analysis/src/Error.cpp
+++ b/Analysis/src/Error.cpp
@@ -19,6 +19,7 @@
 LUAU_FASTINTVARIABLE(LuauIndentTypeMismatchMaxTypeLength, 10)
 LUAU_FASTFLAGVARIABLE(LuauTweakAccessViolationReporting)
 LUAU_FASTFLAGVARIABLE(LuauBetterMissingPropertiesTypeError)
+LUAU_FASTFLAG(LuauBetterPackAndVariadicMismatchErrors)
 
 static std::string wrongNumberOfArgsString(
     size_t expectedCount,
@@ -589,11 +590,23 @@ struct ErrorConverter
         switch (e.kind)
         {
         case Luau::SwappedGenericTypeParameter::Type:
-            return "Variadic type parameter '" + e.name + "...' is used as a regular generic type; consider changing '" + e.name + "...' to '" +
-                   e.name + "' in the generic argument list";
+        {
+            if (FFlag::LuauBetterPackAndVariadicMismatchErrors)
+                return "Generic pack '" + e.name + "...' is used like a generic type; consider changing it to '" +
+                    e.name + "' in the generic argument list or using it as '" + e.name + "...'";
+            else
+                return "Variadic type parameter '" + e.name + "...' is used as a regular generic type; consider changing '" + e.name + "...' to '" +
+                    e.name + "' in the generic argument list";
+        }
         case Luau::SwappedGenericTypeParameter::Pack:
-            return "Generic type '" + e.name + "' is used as a variadic type parameter; consider changing '" + e.name + "' to '" + e.name +
-                   "...' in the generic argument list";
+        {
+            if (FFlag::LuauBetterPackAndVariadicMismatchErrors)
+                return "Generic type '" + e.name + "' is used like a generic pack; consider changing it to '" + e.name +
+                    "...' in the generic argument list or using it as '" + e.name + "' or '..." + e.name + "'";
+            else
+                return "Generic type '" + e.name + "' is used as a variadic type parameter; consider changing '" + e.name + "' to '" + e.name +
+                    "...' in the generic argument list";
+        }
         default:
             LUAU_ASSERT(!"Unknown kind");
             return "";

--- a/Analysis/src/Error.cpp
+++ b/Analysis/src/Error.cpp
@@ -499,8 +499,7 @@ struct ErrorConverter
     {
         if (!FFlag::LuauBetterMissingPropertiesTypeError)
         {
-            std::string s =
-                "Table type '" + toString(e.subType) + "' not compatible with type '" + toString(e.superType) + "' because the former";
+            std::string s = "Table type '" + toString(e.subType) + "' not compatible with type '" + toString(e.superType) + "' because the former";
 
             switch (e.context)
             {

--- a/Analysis/src/Error.cpp
+++ b/Analysis/src/Error.cpp
@@ -18,6 +18,7 @@
 
 LUAU_FASTINTVARIABLE(LuauIndentTypeMismatchMaxTypeLength, 10)
 LUAU_FASTFLAGVARIABLE(LuauTweakAccessViolationReporting)
+LUAU_FASTFLAGVARIABLE(LuauBetterMissingPropertiesTypeError)
 
 static std::string wrongNumberOfArgsString(
     size_t expectedCount,
@@ -496,6 +497,40 @@ struct ErrorConverter
 
     std::string operator()(const Luau::MissingProperties& e) const
     {
+        if (!FFlag::LuauBetterMissingPropertiesTypeError)
+        {
+            std::string s =
+                "Table type '" + toString(e.subType) + "' not compatible with type '" + toString(e.superType) + "' because the former";
+
+            switch (e.context)
+            {
+            case MissingProperties::Missing:
+                s += " is missing field";
+                break;
+            case MissingProperties::Extra:
+                s += " has extra field";
+                break;
+            }
+
+            if (e.properties.size() > 1)
+                s += "s";
+
+            s += " ";
+
+            for (size_t i = 0; i < e.properties.size(); ++i)
+            {
+                if (i > 0)
+                    s += ", ";
+
+                if (i > 0 && i == e.properties.size() - 1)
+                    s += "and ";
+
+                s += "'" + e.properties[i] + "'";
+            }
+
+            return s;
+        }
+
         std::string s;
         std::string afterFieldList;
         std::string pluralSuffix = e.properties.size() > 1 ? "s " : " ";

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -2,6 +2,7 @@
 #include "Luau/Linter.h"
 
 #include "Luau/AstQuery.h"
+#include "Luau/LinterConfig.h"
 #include "Luau/Module.h"
 #include "Luau/Scope.h"
 #include "Luau/TypeInfer.h"
@@ -717,12 +718,6 @@ private:
     struct Local
     {
         AstNode* defined = nullptr;
-<<<<<<< HEAD
-        bool function;
-        bool import;
-        bool used;
-        bool arg;
-=======
         unsigned int scopeDepth = 0;
         bool function = false;
         bool import = false;
@@ -812,35 +807,29 @@ private:
         if (local->name.value[0] == '_')
             return;
 
+        const char* msg;
+        LintWarning::Code warning;
+
         if (info.function)
-<<<<<<< HEAD
-            emitWarning(
-                *context,
-                LintWarning::Code_FunctionUnused,
-                local->location,
-                "Function '%s' is never used; prefix with '_' to silence",
-                local->name.value
-            );
-=======
         {
             warning = LintWarning::Code_FunctionUnused;
-            if (info.usedRecursively)
+            if (info.softUsed)
                 msg = "Function '%s' is never used outside its own body; prefix with '_' to silence";
             else
                 msg = "Function '%s' is never used; prefix with '_' to silence";
         }
->>>>>>> d7d2be8e (renames)
         else if (info.import)
-            emitWarning(
-                *context, LintWarning::Code_ImportUnused, local->location, "Import '%s' is never used; prefix with '_' to silence", local->name.value
-            );
+        {
+            warning = LintWarning::Code_ImportUnused;
+            msg = "Import '%s' is never used; prefix with '_' to silence";
+        }
         else
         {
             warning = LintWarning::Code_LocalUnused;
             msg = "Variable '%s' is never used; prefix with '_' to silence";
         }
 
-        emitWarning(*context, warning, local->location, msg, local->name.value);
+        emitWarning(*context, LintWarning::Code_FunctionUnused, local->location, msg, local->name.value);
     }
 
     bool isRequireCall(AstExpr* expr)
@@ -903,7 +892,11 @@ private:
         l.defined = node;
         l.function = true;
 
-        return true;
+        l.scopeDepth++;
+        node->func->visit(this);
+        l.scopeDepth--;
+
+        return false;
     }
 
     bool visit(AstExprLocal* node) override

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -747,7 +747,7 @@ private:
     {
         for (auto& l : locals)
         {
-            if (l.second.usedOutsideSelf)
+            if (l.second.used)
                 reportUsedLocal(l.first, l.second);
             else if (l.second.defined)
                 reportUnusedLocal(l.first, l.second);
@@ -805,9 +805,6 @@ private:
         if (local->name.value[0] == '_')
             return;
 
-        const char* msg;
-        LintWarning::Code warning;
-
         if (info.function)
             if (info.softUsed)
                 emitWarning(
@@ -827,16 +824,13 @@ private:
                 );
         else if (info.import)
         {
-            warning = LintWarning::Code_ImportUnused;
-            msg = "Import '%s' is never used; prefix with '_' to silence";
+            emitWarning(*context, LintWarning::Code_ImportUnused, local->location, "Import '%s' is never used; prefix with '_' to silence", local->name.value);
         }
         else
         {
-            warning = LintWarning::Code_LocalUnused;
-            msg = "Variable '%s' is never used; prefix with '_' to silence";
+            emitWarning(*context, LintWarning::Code_LocalUnused, local->location, "Variable '%s' is never used; prefix with '_' to silence", local->name.value);
         }
 
-        emitWarning(*context, LintWarning::Code_FunctionUnused, local->location, msg, local->name.value);
     }
 
     bool isRequireCall(AstExpr* expr)
@@ -897,7 +891,7 @@ private:
         Local& l = locals[node->name];
 
         l.defined = node;
-        l.function = true;
+        l.function.emplace(node->location);
 
         return true;
     }
@@ -946,7 +940,7 @@ private:
         AstLocal* astLocal = imports[*node->prefix];
         Local& local = locals[astLocal];
         LUAU_ASSERT(local.import);
-        local.usedOutsideSelf = true;
+        local.used = true;
 
         return true;
     }
@@ -1022,19 +1016,18 @@ private:
     bool visit(AstStatFunction* node) override
     {
         AstExprGlobal* expr = node->name->as<AstExprGlobal>();
-        if (!expr)
-            return true;
-
-        Global& g = globals[expr->name];
-        g.func = true;
-        g.nameLocation = expr->location;
+        if (expr) {
+            Global& g = globals[expr->name];
 
             g.function.emplace(node->location);
             g.location = expr->location;
 
             node->func->visit(this);
 
-        return false;
+            return false;
+        }
+
+        return true;
     }
 
     bool visit(AstExprGlobal* node) override

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -976,18 +976,12 @@ private:
 
     struct Global
     {
-<<<<<<< HEAD
-        Location location;
-        bool function;
-        bool used;
-=======
         unsigned int scopeDepth = 0;
         bool func = false;
-        bool usedOutsideSelf = false;
-        bool usedRecursively = false;
+        bool used = false;
+        bool softUsed = false;
 
         Location nameLocation;
->>>>>>> d7d2be8e (renames)
     };
 
     DenseHashMap<AstName, Global> globals;
@@ -1001,52 +995,41 @@ private:
     {
         for (auto& g : globals)
         {
-<<<<<<< HEAD
-            if (g.second.function && !g.second.used && g.first.value[0] != '_')
-                emitWarning(
-                    *context,
-                    LintWarning::Code_FunctionUnused,
-                    g.second.location,
-                    "Function '%s' is never used; prefix with '_' to silence",
-                    g.first.value
-                );
-=======
-            if (!g.second.func || g.second.usedOutsideSelf || g.first.value[0] == '_')
+            if (!g.second.func || g.second.used || g.first.value[0] == '_')
                 continue;
 
             const char* msg;
-            if (g.second.usedRecursively)
+            if (g.second.softUsed)
                 msg = "Function '%s' is never used outside its own body; prefix with '_' to silence";
             else
                 msg = "Function '%s' is never used; prefix with '_' to silence";
 
             emitWarning(*context, LintWarning::Code_FunctionUnused, g.second.nameLocation, msg, g.first.value);
->>>>>>> d7d2be8e (renames)
         }
     }
 
     bool visit(AstStatFunction* node) override
     {
-        if (AstExprGlobal* expr = node->name->as<AstExprGlobal>())
-        {
-            Global& g = globals[expr->name];
+        AstExprGlobal* expr = node->name->as<AstExprGlobal>();
+        if (!expr)
+            return true;
 
-            g.function = true;
-            g.location = expr->location;
+        Global& g = globals[expr->name];
+        g.func = true;
+        g.nameLocation = expr->location;
 
-            node->func->visit(this);
+        g.scopeDepth++;
+        node->func->visit(this);
+        g.scopeDepth--;
 
-            return false;
-        }
-
-        return true;
+        return false;
     }
 
     bool visit(AstExprGlobal* node) override
     {
         Global& g = globals[node->name];
 
-        if (FFlag::LuauFunctionUnusedRecursiveLinting && g.func && g.scopeDepth > 0)
+        if (g.func && g.scopeDepth > 0)
             g.softUsed = true;
         else
             g.used = true;

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -718,13 +718,11 @@ private:
     struct Local
     {
         AstNode* defined = nullptr;
-        unsigned int scopeDepth = 0;
-        bool function = false;
+        std::optional<Location> function;
         bool import = false;
-        bool usedOutsideSelf = false;
-        bool usedRecursively = false;
+        bool used = false;
+        bool softUsed = false;
         bool arg = false;
->>>>>>> d7d2be8e (renames)
     };
 
     struct Global

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -716,10 +716,19 @@ private:
     struct Local
     {
         AstNode* defined = nullptr;
+<<<<<<< HEAD
         bool function;
         bool import;
         bool used;
         bool arg;
+=======
+        unsigned int scopeDepth = 0;
+        bool function = false;
+        bool import = false;
+        bool usedOutsideSelf = false;
+        bool usedRecursively = false;
+        bool arg = false;
+>>>>>>> d7d2be8e (renames)
     };
 
     struct Global
@@ -744,7 +753,7 @@ private:
     {
         for (auto& l : locals)
         {
-            if (l.second.used)
+            if (l.second.usedOutsideSelf)
                 reportUsedLocal(l.first, l.second);
             else if (l.second.defined)
                 reportUnusedLocal(l.first, l.second);
@@ -803,6 +812,7 @@ private:
             return;
 
         if (info.function)
+<<<<<<< HEAD
             emitWarning(
                 *context,
                 LintWarning::Code_FunctionUnused,
@@ -810,6 +820,15 @@ private:
                 "Function '%s' is never used; prefix with '_' to silence",
                 local->name.value
             );
+=======
+        {
+            warning = LintWarning::Code_FunctionUnused;
+            if (info.usedRecursively)
+                msg = "Function '%s' is never used outside its own body; prefix with '_' to silence";
+            else
+                msg = "Function '%s' is never used; prefix with '_' to silence";
+        }
+>>>>>>> d7d2be8e (renames)
         else if (info.import)
             emitWarning(
                 *context, LintWarning::Code_ImportUnused, local->location, "Import '%s' is never used; prefix with '_' to silence", local->name.value
@@ -887,7 +906,14 @@ private:
     {
         Local& l = locals[node->local];
 
+<<<<<<< HEAD
         l.used = true;
+=======
+        if (FFlag::LuauFunctionUnusedRecursiveLinting && l.function && l.scopeDepth > 0)
+            l.usedRecursively = true;
+        else
+            l.usedOutsideSelf = true;
+>>>>>>> d7d2be8e (renames)
 
         return true;
     }
@@ -924,7 +950,7 @@ private:
         AstLocal* astLocal = imports[*node->prefix];
         Local& local = locals[astLocal];
         LUAU_ASSERT(local.import);
-        local.used = true;
+        local.usedOutsideSelf = true;
 
         return true;
     }
@@ -959,9 +985,18 @@ private:
 
     struct Global
     {
+<<<<<<< HEAD
         Location location;
         bool function;
         bool used;
+=======
+        unsigned int scopeDepth = 0;
+        bool func = false;
+        bool usedOutsideSelf = false;
+        bool usedRecursively = false;
+
+        Location nameLocation;
+>>>>>>> d7d2be8e (renames)
     };
 
     DenseHashMap<AstName, Global> globals;
@@ -975,6 +1010,7 @@ private:
     {
         for (auto& g : globals)
         {
+<<<<<<< HEAD
             if (g.second.function && !g.second.used && g.first.value[0] != '_')
                 emitWarning(
                     *context,
@@ -983,6 +1019,18 @@ private:
                     "Function '%s' is never used; prefix with '_' to silence",
                     g.first.value
                 );
+=======
+            if (!g.second.func || g.second.usedOutsideSelf || g.first.value[0] == '_')
+                continue;
+
+            const char* msg;
+            if (g.second.usedRecursively)
+                msg = "Function '%s' is never used outside its own body; prefix with '_' to silence";
+            else
+                msg = "Function '%s' is never used; prefix with '_' to silence";
+
+            emitWarning(*context, LintWarning::Code_FunctionUnused, g.second.nameLocation, msg, g.first.value);
+>>>>>>> d7d2be8e (renames)
         }
     }
 
@@ -1007,7 +1055,14 @@ private:
     {
         Global& g = globals[node->name];
 
+<<<<<<< HEAD
         g.used = true;
+=======
+        if (FFlag::LuauFunctionUnusedRecursiveLinting && g.func && g.scopeDepth > 0)
+            g.usedRecursively = true;
+        else
+            g.usedOutsideSelf = true;
+>>>>>>> d7d2be8e (renames)
 
         return true;
     }

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -719,10 +719,10 @@ private:
     {
         AstNode* defined = nullptr;
         std::optional<Location> function;
-        bool import = false;
-        bool used = false;
-        bool softUsed = false;
-        bool arg = false;
+        bool import;
+        bool used;
+        bool softUsed;
+        bool arg;
     };
 
     struct Global
@@ -809,13 +809,22 @@ private:
         LintWarning::Code warning;
 
         if (info.function)
-        {
-            warning = LintWarning::Code_FunctionUnused;
             if (info.softUsed)
-                msg = "Function '%s' is never used outside its own body; prefix with '_' to silence";
+                emitWarning(
+                    *context,
+                    LintWarning::Code_FunctionUnused,
+                    local->location,
+                    "Function '%s' is never used outside its own body; prefix with '_' to silence",
+                    local->name.value
+                );
             else
-                msg = "Function '%s' is never used; prefix with '_' to silence";
-        }
+                emitWarning(
+                    *context,
+                    LintWarning::Code_FunctionUnused,
+                    local->location,
+                    "Function '%s' is never used; prefix with '_' to silence",
+                    local->name.value
+                );
         else if (info.import)
         {
             warning = LintWarning::Code_ImportUnused;
@@ -890,18 +899,14 @@ private:
         l.defined = node;
         l.function = true;
 
-        l.scopeDepth++;
-        node->func->visit(this);
-        l.scopeDepth--;
-
-        return false;
+        return true;
     }
 
     bool visit(AstExprLocal* node) override
     {
         Local& l = locals[node->local];
 
-        if (FFlag::LuauFunctionUnusedRecursiveLinting && l.function && l.scopeDepth > 0)
+        if (l.function && l.function.value().contains(node->location.begin))
             l.softUsed = true;
         else
             l.used = true;
@@ -976,12 +981,10 @@ private:
 
     struct Global
     {
-        unsigned int scopeDepth = 0;
-        bool func = false;
-        bool used = false;
-        bool softUsed = false;
-
-        Location nameLocation;
+        Location location;
+        std::optional<Location> function;
+        bool softUsed;
+        bool used;
     };
 
     DenseHashMap<AstName, Global> globals;
@@ -995,16 +998,24 @@ private:
     {
         for (auto& g : globals)
         {
-            if (!g.second.func || g.second.used || g.first.value[0] == '_')
+            if (!g.second.function || g.second.used || g.first.value[0] == '_')
                 continue;
-
-            const char* msg;
             if (g.second.softUsed)
-                msg = "Function '%s' is never used outside its own body; prefix with '_' to silence";
+                emitWarning(
+                    *context,
+                    LintWarning::Code_FunctionUnused,
+                    g.second.location,
+                    "Function '%s' is never used outside its own body; prefix with '_' to silence",
+                    g.first.value
+                );
             else
-                msg = "Function '%s' is never used; prefix with '_' to silence";
-
-            emitWarning(*context, LintWarning::Code_FunctionUnused, g.second.nameLocation, msg, g.first.value);
+                emitWarning(
+                    *context,
+                    LintWarning::Code_FunctionUnused,
+                    g.second.location,
+                    "Function '%s' is never used; prefix with '_' to silence",
+                    g.first.value
+                );
         }
     }
 
@@ -1018,9 +1029,10 @@ private:
         g.func = true;
         g.nameLocation = expr->location;
 
-        g.scopeDepth++;
-        node->func->visit(this);
-        g.scopeDepth--;
+            g.function.emplace(node->location);
+            g.location = expr->location;
+
+            node->func->visit(this);
 
         return false;
     }
@@ -1029,7 +1041,7 @@ private:
     {
         Global& g = globals[node->name];
 
-        if (g.func && g.scopeDepth > 0)
+        if (g.function && g.function.value().contains(node->location.begin))
             g.softUsed = true;
         else
             g.used = true;

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -13,6 +13,7 @@
 #include <climits>
 
 LUAU_FASTINTVARIABLE(LuauSuggestionDistance, 4)
+LUAU_FASTFLAGVARIABLE(LuauFunctionUnusedRecursiveLinting)
 
 namespace Luau
 {
@@ -906,14 +907,10 @@ private:
     {
         Local& l = locals[node->local];
 
-<<<<<<< HEAD
-        l.used = true;
-=======
         if (FFlag::LuauFunctionUnusedRecursiveLinting && l.function && l.scopeDepth > 0)
-            l.usedRecursively = true;
+            l.softUsed = true;
         else
-            l.usedOutsideSelf = true;
->>>>>>> d7d2be8e (renames)
+            l.used = true;
 
         return true;
     }
@@ -1055,14 +1052,10 @@ private:
     {
         Global& g = globals[node->name];
 
-<<<<<<< HEAD
-        g.used = true;
-=======
         if (FFlag::LuauFunctionUnusedRecursiveLinting && g.func && g.scopeDepth > 0)
-            g.usedRecursively = true;
+            g.softUsed = true;
         else
-            g.usedOutsideSelf = true;
->>>>>>> d7d2be8e (renames)
+            g.used = true;
 
         return true;
     }

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -835,9 +835,12 @@ private:
                 *context, LintWarning::Code_ImportUnused, local->location, "Import '%s' is never used; prefix with '_' to silence", local->name.value
             );
         else
-            emitWarning(
-                *context, LintWarning::Code_LocalUnused, local->location, "Variable '%s' is never used; prefix with '_' to silence", local->name.value
-            );
+        {
+            warning = LintWarning::Code_LocalUnused;
+            msg = "Variable '%s' is never used; prefix with '_' to silence";
+        }
+
+        emitWarning(*context, warning, local->location, msg, local->name.value);
     }
 
     bool isRequireCall(AstExpr* expr)

--- a/Analysis/src/OverloadResolver.cpp
+++ b/Analysis/src/OverloadResolver.cpp
@@ -387,6 +387,20 @@ void OverloadResolver::reportErrors(
             // satisfied.
 
             maybeEmplaceError(&errors, argLocation, moduleName, &reason, failedSuperPack, failedSubPack.value_or(builtinTypes->emptyTypePack));
+
+            if (FFlag::LuauBetterPackAndVariadicMismatchErrors && failedSubPack.has_value())
+            {
+                if (const GenericTypePack* gtp = get<GenericTypePack>(*failedSubPack); gtp && gtp->explicitName)
+                {
+                    TypePackMismatch* error = get<TypePackMismatch>(errors.back());
+                    LUAU_ASSERT(error);
+
+                    const std::string& name = gtp->name;
+                    error->reason = "the former is a variadic, and the latter is a generic pack; "
+                                        "consider changing the generic to '"+ name + "', and the variadic parameter to "
+                                        " '...: " + name + "'";
+                }
+            }
         }
         else
             errors.emplace_back(fnLocation, moduleName, CountMismatch{paramsHead.size(), optMaxParams, argCount, CountMismatch::Arg, isVariadic});

--- a/Analysis/src/OverloadResolver.cpp
+++ b/Analysis/src/OverloadResolver.cpp
@@ -14,6 +14,7 @@
 #include "Luau/Unifier2.h"
 
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
+LUAU_FASTFLAG(LuauBetterPackAndVariadicMismatchErrors)
 
 namespace Luau
 {
@@ -398,7 +399,7 @@ void OverloadResolver::reportErrors(
                     const std::string& name = gtp->name;
                     error->reason = "the former is a variadic, and the latter is a generic pack; "
                                         "consider changing the generic to '"+ name + "', and the variadic parameter to "
-                                        " '...: " + name + "'";
+                                        " '...: " + name + "'.";
                 }
             }
         }

--- a/Analysis/src/Subtyping.cpp
+++ b/Analysis/src/Subtyping.cpp
@@ -31,6 +31,7 @@ LUAU_FASTFLAGVARIABLE(LuauDropUnionSubtypeReasoning)
 LUAU_FASTFLAGVARIABLE(LuauDontBindOptionalGenericToNil)
 LUAU_FASTFLAGVARIABLE(LuauImproveUniqueTableWidthSubtyping)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
+LUAU_FASTFLAG(LuauIndexerModifierMismatchErrors)
 
 namespace Luau
 {
@@ -38,13 +39,13 @@ namespace Luau
 bool SubtypingReasoning::operator==(const SubtypingReasoning& other) const
 {
     return subPath == other.subPath && superPath == other.superPath && variance == other.variance &&
-           isPropertyModifierViolation == other.isPropertyModifierViolation;
+           isAccessModifierViolation == other.isAccessModifierViolation;
 }
 
 size_t SubtypingReasoningHash::operator()(const SubtypingReasoning& r) const
 {
     return TypePath::PathHash()(r.subPath) ^ (TypePath::PathHash()(r.superPath) << 1) ^ (static_cast<size_t>(r.variance) << 1) ^
-           (static_cast<size_t>(r.isPropertyModifierViolation) << 2);
+           (static_cast<size_t>(r.isAccessModifierViolation) << 2);
 }
 
 MappedGenericEnvironment::MappedGenericFrame::MappedGenericFrame(
@@ -373,10 +374,10 @@ SubtypingResult& SubtypingResult::withError(TypeError err)
     return *this;
 }
 
-SubtypingResult& SubtypingResult::withPropertyModifierViolation()
+SubtypingResult& SubtypingResult::withAccessModifierViolation()
 {
     for (auto& r : reasoning)
-        r.isPropertyModifierViolation = true;
+        r.isAccessModifierViolation = true;
     return *this;
 }
 
@@ -2535,20 +2536,32 @@ SubtypingResult Subtyping::isCovariantWith(
         if (subIndexer.isReadOnly && !superIndexer.isReadOnly)
             return result.withBothComponent(TypePath::TypeField::IndexResult);
 
+        if (!FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
+            return result.withBothComponent(TypePath::TypeField::IndexResult);
+
         result = isInvariantWith(env, subIndexer.indexType, superIndexer.indexType, scope).withBothComponent(TypePath::TypeField::IndexLookup);
 
         // Value-type variance: read-only super → covariant; read-write super → invariant.
         if (superIndexer.isReadOnly)
             result.andAlso(isCovariantWith(env, subIndexer.indexResultType, superIndexer.indexResultType, scope)
-                               .withBothComponent(TypePath::TypeField::IndexResult));
+                            .withBothComponent(TypePath::TypeField::IndexResult));
         else
             result.andAlso(isInvariantWith(env, subIndexer.indexResultType, superIndexer.indexResultType, scope)
-                               .withBothComponent(TypePath::TypeField::IndexResult));
+                            .withBothComponent(TypePath::TypeField::IndexResult));
 
-    if (FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
-        result.andAlso(SubtypingResult{false}.withBothComponent(TypePath::TypeField::IndexResult).withAccessModifierViolation());
+        if (FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
+            result.withBothComponent(TypePath::TypeField::IndexResult).withAccessModifierViolation();
 
-    return result;
+        if (FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
+            result.andAlso(SubtypingResult{false}.withBothComponent(TypePath::TypeField::IndexResult).withAccessModifierViolation());
+
+        return result;
+    } else {
+        return isInvariantWith(env, subIndexer.indexType, superIndexer.indexType, scope)
+            .withBothComponent(TypePath::TypeField::IndexLookup)
+            .andAlso(isInvariantWith(env, subIndexer.indexResultType, superIndexer.indexResultType, scope)
+                         .withBothComponent(TypePath::TypeField::IndexResult));
+    }
 }
 
 SubtypingResult Subtyping::isCovariantWith(
@@ -2581,14 +2594,14 @@ SubtypingResult Subtyping::isCovariantWith(
             if (subProp.isReadOnly())
             {
                 if (FFlag::LuauPropertyModifierMismatchErrors)
-                    res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::read(name)).withPropertyModifierViolation());
+                    res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::read(name)).withAccessModifierViolation());
                 else
                     res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::read(name)));
             }
             else if (subProp.isWriteOnly())
             {
                 if (FFlag::LuauPropertyModifierMismatchErrors)
-                    res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::write(name)).withPropertyModifierViolation());
+                    res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::write(name)).withAccessModifierViolation());
                 else
                     res.andAlso(SubtypingResult{false}.withBothComponent(TypePath::Property::write(name)));
             }

--- a/Analysis/src/Subtyping.cpp
+++ b/Analysis/src/Subtyping.cpp
@@ -2545,15 +2545,10 @@ SubtypingResult Subtyping::isCovariantWith(
             result.andAlso(isInvariantWith(env, subIndexer.indexResultType, superIndexer.indexResultType, scope)
                                .withBothComponent(TypePath::TypeField::IndexResult));
 
-        return result;
-    }
-    else
-    {
-        return isInvariantWith(env, subIndexer.indexType, superIndexer.indexType, scope)
-            .withBothComponent(TypePath::TypeField::IndexLookup)
-            .andAlso(isInvariantWith(env, subIndexer.indexResultType, superIndexer.indexResultType, scope)
-                         .withBothComponent(TypePath::TypeField::IndexResult));
-    }
+    if (FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
+        result.andAlso(SubtypingResult{false}.withBothComponent(TypePath::TypeField::IndexResult).withAccessModifierViolation());
+
+    return result;
 }
 
 SubtypingResult Subtyping::isCovariantWith(

--- a/Analysis/src/Subtyping.cpp
+++ b/Analysis/src/Subtyping.cpp
@@ -2533,9 +2533,6 @@ SubtypingResult Subtyping::isCovariantWith(
     if (FFlag::LuauReadOnlyIndexers)
     {
         SubtypingResult result{false};
-        if (subIndexer.isReadOnly && !superIndexer.isReadOnly)
-            return result.withBothComponent(TypePath::TypeField::IndexResult);
-
         if (!FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
             return result.withBothComponent(TypePath::TypeField::IndexResult);
 
@@ -2548,9 +2545,6 @@ SubtypingResult Subtyping::isCovariantWith(
         else
             result.andAlso(isInvariantWith(env, subIndexer.indexResultType, superIndexer.indexResultType, scope)
                             .withBothComponent(TypePath::TypeField::IndexResult));
-
-        if (FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
-            result.withBothComponent(TypePath::TypeField::IndexResult).withAccessModifierViolation();
 
         if (FFlag::LuauIndexerModifierMismatchErrors && (subIndexer.isReadOnly && !superIndexer.isReadOnly))
             result.andAlso(SubtypingResult{false}.withBothComponent(TypePath::TypeField::IndexResult).withAccessModifierViolation());

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -3089,23 +3089,50 @@ Reasonings TypeChecker2::explainReasonings_(TID subTy, TID superTy, Location loc
 
         std::stringstream reason;
 
-        if (FFlag::LuauPropertyModifierMismatchErrors && reasoning.isPropertyModifierViolation)
+        if ((FFlag::LuauPropertyModifierMismatchErrors || FFlag::LuauIndexerModifierMismatchErrors) && reasoning.isAccessModifierViolation)
         {
-            // The leaf types at the end of the paths are the same type, so a
-            // plain "X is not a subtype of X" message would be misleading.
-            // Instead, explain that the mismatch is about the property modifier.
-            std::string propName = "a property";
-            bool isReadOnly = true;
-            auto last = reasoning.subPath.last();
-            LUAU_ASSERT(last && get_if<TypePath::Property>(&*last));
-            if (last)
+            if (FFlag::LuauPropertyModifierMismatchErrors && FFlag::LuauIndexerModifierMismatchErrors)
             {
-                if (auto* prop = get_if<TypePath::Property>(&*last))
+                // The leaf types at the end of the paths are the same type, so a
+                // plain "X is not a subtype of X" message would be misleading.
+                // Instead, explain that the mismatch is about the access modifier.
+                auto last = reasoning.subPath.last();
+                bool isReadOnly = true;
+                std::string path = "something";
+
+                if (last)
                 {
-                    propName = "`" + prop->name + "`";
-                    isReadOnly = prop->isRead;
+                    if (auto* prop = get_if<TypePath::Property>(&*last))
+                    {
+                        path = "`" + prop->name + "`";
+                        isReadOnly = prop->isRead;
+                    }
+                    else if (auto* field = get_if<TypePath::TypeField>(&*last); field && *field == TypePath::TypeField::IndexResult)
+                        path = "the indexer";
                 }
+
+                if (isReadOnly)
+                    reason << path << " is read-only in the latter type, but the former type requires it to be read-write";
+                else
+                    reason << path << " is write-only in the latter type, but the former type requires it to be read-write";
             }
+            else if (FFlag::LuauPropertyModifierMismatchErrors)
+            {
+                // The leaf types at the end of the paths are the same type, so a
+                // plain "X is not a subtype of X" message would be misleading.
+                // Instead, explain that the mismatch is about the property modifier.
+                std::string propName = "a property";
+                bool isReadOnly = true;
+                auto last = reasoning.subPath.last();
+                LUAU_ASSERT(last && get_if<TypePath::Property>(&*last));
+                if (last)
+                {
+                    if (auto* prop = get_if<TypePath::Property>(&*last))
+                    {
+                        propName = "`" + prop->name + "`";
+                        isReadOnly = prop->isRead;
+                    }
+                }
 
             if (isReadOnly)
                 reason << propName << " is a read-only property in the latter type, but the former type requires a read-write property";

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -40,6 +40,7 @@ LUAU_FASTFLAG(LuauTweakAccessViolationReporting)
 LUAU_FASTFLAG(LuauReadOnlyIndexers)
 LUAU_FASTFLAG(LuauImproveUniqueTableWidthSubtyping)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
+LUAU_FASTFLAGVARIABLE(LuauBetterPackAndVariadicMismatchErrors)
 
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauDefaultArguments)
@@ -3122,6 +3123,19 @@ Reasonings TypeChecker2::explainReasonings_(TID subTy, TID superTy, Location loc
                    << "`";
         else
             reason << toStringHuman(reasoning.superPath) << "`" << superLeafAsString << "`, and " << baseReason;
+
+        if (FFlag::LuauBetterPackAndVariadicMismatchErrors && reasoning.variance == SubtypingVariance::Contravariant && subLeafTp && superLeafTp)
+        {
+            const VariadicTypePack* vtp = get<VariadicTypePack>(*subLeafTp);
+            const GenericTypePack* gtp = get<GenericTypePack>(*superLeafTp);
+
+            if (gtp && vtp && gtp->explicitName && is<GenericType>(vtp->ty))
+            {
+                reason << "; the former type has a generic pack, and the latter type has a variadic, ";
+                reason << "consider changing the former generic to `" << gtp->name << "` or the latter generic to ";
+                reason << "`" << toString(vtp->ty) << "...`";
+            }
+        }
 
         reasons.push_back(reason.str());
 

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -3100,43 +3100,6 @@ Reasonings TypeChecker2::explainReasonings_(TID subTy, TID superTy, Location loc
                 auto last = reasoning.subPath.last();
                 bool isReadOnly = true;
                 std::string path = "something";
-<<<<<<< HEAD
-
-                if (last)
-                {
-                    if (auto* prop = get_if<TypePath::Property>(&*last))
-                    {
-                        path = "`" + prop->name + "`";
-                        isReadOnly = prop->isRead;
-                    }
-                    else if (auto* field = get_if<TypePath::TypeField>(&*last); field && *field == TypePath::TypeField::IndexResult)
-                        path = "the indexer";
-                }
-
-                if (isReadOnly)
-                    reason << path << " is read-only in the latter type, but the former type requires it to be read-write";
-                else
-                    reason << path << " is write-only in the latter type, but the former type requires it to be read-write";
-            }
-            else if (FFlag::LuauPropertyModifierMismatchErrors)
-            {
-                // The leaf types at the end of the paths are the same type, so a
-                // plain "X is not a subtype of X" message would be misleading.
-                // Instead, explain that the mismatch is about the property modifier.
-                std::string propName = "a property";
-                bool isReadOnly = true;
-                auto last = reasoning.subPath.last();
-                LUAU_ASSERT(last && get_if<TypePath::Property>(&*last));
-                if (last)
-                {
-                    if (auto* prop = get_if<TypePath::Property>(&*last))
-                    {
-                        propName = "`" + prop->name + "`";
-                        isReadOnly = prop->isRead;
-                    }
-                }
-=======
->>>>>>> b33b0145 (the implement, do)
 
                 if (last)
                 {

--- a/Analysis/src/TypeChecker2.cpp
+++ b/Analysis/src/TypeChecker2.cpp
@@ -38,6 +38,7 @@ LUAU_FASTFLAGVARIABLE(LuauCheckFunctionStatementTypes)
 LUAU_FASTFLAGVARIABLE(LuauPropertyModifierMismatchErrors)
 LUAU_FASTFLAG(LuauTweakAccessViolationReporting)
 LUAU_FASTFLAG(LuauReadOnlyIndexers)
+LUAU_FASTFLAGVARIABLE(LuauIndexerModifierMismatchErrors)
 LUAU_FASTFLAG(LuauImproveUniqueTableWidthSubtyping)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
 LUAU_FASTFLAGVARIABLE(LuauBetterPackAndVariadicMismatchErrors)
@@ -3099,6 +3100,7 @@ Reasonings TypeChecker2::explainReasonings_(TID subTy, TID superTy, Location loc
                 auto last = reasoning.subPath.last();
                 bool isReadOnly = true;
                 std::string path = "something";
+<<<<<<< HEAD
 
                 if (last)
                 {
@@ -3133,11 +3135,48 @@ Reasonings TypeChecker2::explainReasonings_(TID subTy, TID superTy, Location loc
                         isReadOnly = prop->isRead;
                     }
                 }
+=======
+>>>>>>> b33b0145 (the implement, do)
 
-            if (isReadOnly)
-                reason << propName << " is a read-only property in the latter type, but the former type requires a read-write property";
+                if (last)
+                {
+                    if (auto* prop = get_if<TypePath::Property>(&*last))
+                    {
+                        path = "`" + prop->name + "`";
+                        isReadOnly = prop->isRead;
+                    }
+                    else if (auto* field = get_if<TypePath::TypeField>(&*last); field && *field == TypePath::TypeField::IndexResult)
+                        path = "the indexer";
+                }
+
+                if (isReadOnly)
+                    reason << path << " is read-only in the latter type, but the former type requires it to be read-write";
+                else
+                    reason << path << " is write-only in the latter type, but the former type requires it to be read-write";
+            }
             else
-                reason << propName << " is a write-only property in the latter type, but the former type requires a read-write property";
+            {
+                // The leaf types at the end of the paths are the same type, so a
+                // plain "X is not a subtype of X" message would be misleading.
+                // Instead, explain that the mismatch is about the property modifier.
+                std::string propName = "a property";
+                bool isReadOnly = true;
+                auto last = reasoning.subPath.last();
+                LUAU_ASSERT(last && get_if<TypePath::Property>(&*last));
+                if (last)
+                {
+                    if (auto* prop = get_if<TypePath::Property>(&*last))
+                    {
+                        propName = "`" + prop->name + "`";
+                        isReadOnly = prop->isRead;
+                    }
+                }
+
+                if (isReadOnly)
+                    reason << propName << " is a read-only property in the latter type, but the former type requires a read-write property";
+                else
+                    reason << propName << " is a write-only property in the latter type, but the former type requires a read-write property";
+            }
         }
         else if (reasoning.subPath == reasoning.superPath)
             reason << toStringHuman(reasoning.subPath) << "`" << subLeafAsString << "` in the latter type and `" << superLeafAsString

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,8 @@
 - LuauGenericNominals, LuauExternTypeGenericMethods, and LuauExternTypeUseDefinitionScope: @deviaze
 - LuauNonePrimitive: @cheesycod
 - LuauExternalString (and DebugLuauAllowNonNullTerminatedStrings for tests): @cheesycod
+- LuauFunctionUnusedRecursiveLinting, LuauBetterPackAndVariadicMismatchErrors, LuauIndexerModifierMismatchErrors, LuauPropertyModifierMismatchErrors: @PhoenixWhitefire (merged from upstream)
+- LuauBetterMissingPropertiesTypeError, LuauFunctionUnusedRecursiveLinting: @nnullcolumn (merged from upstream)
 
 ## Other
 

--- a/VM/src/lbuffer.cpp
+++ b/VM/src/lbuffer.cpp
@@ -11,7 +11,7 @@
 Buffer* luaB_newbuffer(lua_State* L, size_t s)
 {
     if (s > MAX_BUFFER_SIZE)
-        luaM_toobig(L);
+        luaM_toobig(L, "buffer too big");
 
     Buffer* b = luaM_newgco(L, Buffer, sizebuffer(s), L->activememcat);
     luaC_init(L, b, LUA_TBUFFER);

--- a/VM/src/lbuffer.cpp
+++ b/VM/src/lbuffer.cpp
@@ -11,7 +11,7 @@
 Buffer* luaB_newbuffer(lua_State* L, size_t s)
 {
     if (s > MAX_BUFFER_SIZE)
-        luaM_toobig(L, "buffer too big");
+        luaM_toobig(L, "buffer too big (exceeds maximum of 1GiB)");
 
     Buffer* b = luaM_newgco(L, Buffer, sizebuffer(s), L->activememcat);
     luaC_init(L, b, LUA_TBUFFER);

--- a/VM/src/lbuffer.cpp
+++ b/VM/src/lbuffer.cpp
@@ -11,7 +11,7 @@
 Buffer* luaB_newbuffer(lua_State* L, size_t s)
 {
     if (s > MAX_BUFFER_SIZE)
-        luaM_toobig(L, "buffer too big");
+        luaM_toobig(L, "buffer too big", MAX_BUFFER_SIZE);
 
     Buffer* b = luaM_newgco(L, Buffer, sizebuffer(s), L->activememcat);
     luaC_init(L, b, LUA_TBUFFER);

--- a/VM/src/lbuffer.cpp
+++ b/VM/src/lbuffer.cpp
@@ -11,7 +11,7 @@
 Buffer* luaB_newbuffer(lua_State* L, size_t s)
 {
     if (s > MAX_BUFFER_SIZE)
-        luaM_toobig(L, "buffer too big (exceeds maximum of 1GiB)");
+        luaM_toobig(L, "buffer too big");
 
     Buffer* b = luaM_newgco(L, Buffer, sizebuffer(s), L->activememcat);
     luaC_init(L, b, LUA_TBUFFER);

--- a/VM/src/lbuffer.cpp
+++ b/VM/src/lbuffer.cpp
@@ -30,7 +30,7 @@ Buffer* luaB_newexternalbuffer(lua_State* L, size_t s, void* data, void* userdat
     {
         if (free_cb)
             free_cb(L, data, s, userdata);
-        luaM_toobig(L);
+        luaM_toobig(L, "ext. buffer too big", MAX_BUFFER_SIZE);
     }
 
     struct AllocContext

--- a/VM/src/lmem.cpp
+++ b/VM/src/lmem.cpp
@@ -232,9 +232,9 @@ struct lua_Page
 
 static_assert(offsetof(lua_Page, data) % 16 == 0, "data must be 16 byte aligned to provide properly aligned allocation of userdata objects");
 
-l_noret luaM_toobig(lua_State* L)
+l_noret luaM_toobig(lua_State* L, const char* msg)
 {
-    luaG_runerror(L, "memory allocation error: block too big");
+    luaG_runerror(L, "memory allocation error: %s", msg);
 }
 
 static lua_Page* newpage(lua_State* L, lua_Page** pageset, int pageSize, int blockSize, int blockCount)

--- a/VM/src/lmem.cpp
+++ b/VM/src/lmem.cpp
@@ -232,9 +232,9 @@ struct lua_Page
 
 static_assert(offsetof(lua_Page, data) % 16 == 0, "data must be 16 byte aligned to provide properly aligned allocation of userdata objects");
 
-l_noret luaM_toobig(lua_State* L, const char* msg)
+l_noret luaM_toobig(lua_State* L, const char* msg, size_t max)
 {
-    luaG_runerror(L, "memory allocation error: %s", msg);
+    luaG_runerror(L, "memory allocation error: %s (exceeds maximum of %zi bytes)", msg, max);
 }
 
 static lua_Page* newpage(lua_State* L, lua_Page** pageset, int pageSize, int blockSize, int blockCount)

--- a/VM/src/lmem.cpp
+++ b/VM/src/lmem.cpp
@@ -148,6 +148,8 @@ const size_t kLargePageSize = 32 * 1024 - kExternalAllocatorMetaDataReduction;
 const size_t kBlockHeader = sizeof(double) > sizeof(void*) ? sizeof(double) : sizeof(void*); // suitable for aligning double & void* on all platforms
 const size_t kGCOLinkOffset = (sizeof(GCheader) + sizeof(void*) - 1) & ~(sizeof(void*) - 1); // GCO pages contain freelist links after the GC header
 
+const size_t kGibSize = 1073741824;
+
 struct SizeClassConfig
 {
     int sizeOfClass[kSizeClasses];
@@ -234,7 +236,8 @@ static_assert(offsetof(lua_Page, data) % 16 == 0, "data must be 16 byte aligned 
 
 l_noret luaM_toobig(lua_State* L, const char* msg, size_t max)
 {
-    luaG_runerror(L, "memory allocation error: %s (exceeds maximum of %zi bytes)", msg, max);
+    double sizeGib = static_cast<double>(max) / static_cast<double>(kGibSize);
+    luaG_runerror(L, "memory allocation error: %s (exceeds maximum of %.02f GiB)", msg, sizeGib);
 }
 
 static lua_Page* newpage(lua_State* L, lua_Page** pageset, int pageSize, int blockSize, int blockCount)

--- a/VM/src/lmem.h
+++ b/VM/src/lmem.h
@@ -10,7 +10,7 @@ union GCObject;
 #define luaM_newgco(L, t, size, memcat) cast_to(t*, luaM_newgco_(L, size, memcat))
 #define luaM_freegco(L, p, size, memcat, page) luaM_freegco_(L, obj2gco(p), size, memcat, page)
 
-#define luaM_arraysize_(L, n, e) ((cast_to(size_t, (n)) <= SIZE_MAX / (e)) ? (n) * (e) : (luaM_toobig(L), SIZE_MAX))
+#define luaM_arraysize_(L, n, e) ((cast_to(size_t, (n)) <= SIZE_MAX / (e)) ? (n) * (e) : (luaM_toobig(L, "block too big"), SIZE_MAX))
 
 #define luaM_newarray(L, n, t, memcat) cast_to(t*, luaM_new_(L, luaM_arraysize_(L, n, sizeof(t)), memcat))
 #define luaM_freearray(L, b, n, t, memcat) luaM_free_(L, (b), (n) * sizeof(t), memcat)
@@ -23,7 +23,7 @@ LUAI_FUNC void luaM_free_(lua_State* L, void* block, size_t osize, uint8_t memca
 LUAI_FUNC void luaM_freegco_(lua_State* L, GCObject* block, size_t osize, uint8_t memcat, lua_Page* page);
 LUAI_FUNC void* luaM_realloc_(lua_State* L, void* block, size_t osize, size_t nsize, uint8_t memcat);
 
-LUAI_FUNC l_noret luaM_toobig(lua_State* L);
+LUAI_FUNC l_noret luaM_toobig(lua_State* L, const char* msg);
 
 LUAI_FUNC void luaM_getpagewalkinfo(lua_Page* page, char** start, char** end, int* busyBlocks, int* blockSize);
 LUAI_FUNC void luaM_getpageinfo(lua_Page* page, int* pageBlocks, int* busyBlocks, int* blockSize, int* pageSize);

--- a/VM/src/lmem.h
+++ b/VM/src/lmem.h
@@ -10,7 +10,7 @@ union GCObject;
 #define luaM_newgco(L, t, size, memcat) cast_to(t*, luaM_newgco_(L, size, memcat))
 #define luaM_freegco(L, p, size, memcat, page) luaM_freegco_(L, obj2gco(p), size, memcat, page)
 
-#define luaM_arraysize_(L, n, e) ((cast_to(size_t, (n)) <= SIZE_MAX / (e)) ? (n) * (e) : (luaM_toobig(L, "block too big"), SIZE_MAX))
+#define luaM_arraysize_(L, n, e) ((cast_to(size_t, (n)) <= SIZE_MAX / (e)) ? (n) * (e) : (luaM_toobig(L, "block too big", SIZE_MAX), SIZE_MAX))
 
 #define luaM_newarray(L, n, t, memcat) cast_to(t*, luaM_new_(L, luaM_arraysize_(L, n, sizeof(t)), memcat))
 #define luaM_freearray(L, b, n, t, memcat) luaM_free_(L, (b), (n) * sizeof(t), memcat)
@@ -23,7 +23,7 @@ LUAI_FUNC void luaM_free_(lua_State* L, void* block, size_t osize, uint8_t memca
 LUAI_FUNC void luaM_freegco_(lua_State* L, GCObject* block, size_t osize, uint8_t memcat, lua_Page* page);
 LUAI_FUNC void* luaM_realloc_(lua_State* L, void* block, size_t osize, size_t nsize, uint8_t memcat);
 
-LUAI_FUNC l_noret luaM_toobig(lua_State* L, const char* msg);
+LUAI_FUNC l_noret luaM_toobig(lua_State* L, const char* msg, size_t max);
 
 LUAI_FUNC void luaM_getpagewalkinfo(lua_Page* page, char** start, char** end, int* busyBlocks, int* blockSize);
 LUAI_FUNC void luaM_getpageinfo(lua_Page* page, int* pageBlocks, int* busyBlocks, int* blockSize, int* pageSize);

--- a/VM/src/lstring.cpp
+++ b/VM/src/lstring.cpp
@@ -74,7 +74,7 @@ void luaS_resize(lua_State* L, int newsize)
 static TString* newlstr(lua_State* L, const char* str, size_t l, unsigned int h)
 {
     if (l > MAXSSIZE)
-        luaM_toobig(L, "string too big");
+        luaM_toobig(L, "string too big (exceeds maximum of 1GiB)");
 
     TString* ts = luaM_newgco(L, TString, sizestring(l), L->activememcat);
     luaC_init(L, ts, LUA_TSTRING);
@@ -101,7 +101,7 @@ static TString* newlstr(lua_State* L, const char* str, size_t l, unsigned int h)
 TString* luaS_bufstart(lua_State* L, size_t size)
 {
     if (size > MAXSSIZE)
-        luaM_toobig(L, "string too big");
+        luaM_toobig(L, "string too big (exceeds maximum of 1GiB)");
 
     TString* ts = luaM_newgco(L, TString, sizestring(size), L->activememcat);
     luaC_init(L, ts, LUA_TSTRING);

--- a/VM/src/lstring.cpp
+++ b/VM/src/lstring.cpp
@@ -74,7 +74,7 @@ void luaS_resize(lua_State* L, int newsize)
 static TString* newlstr(lua_State* L, const char* str, size_t l, unsigned int h)
 {
     if (l > MAXSSIZE)
-        luaM_toobig(L, "string too big");
+        luaM_toobig(L, "string too big", MAXSSIZE);
 
     TString* ts = luaM_newgco(L, TString, sizestring(l), L->activememcat);
     luaC_init(L, ts, LUA_TSTRING);
@@ -101,7 +101,7 @@ static TString* newlstr(lua_State* L, const char* str, size_t l, unsigned int h)
 TString* luaS_bufstart(lua_State* L, size_t size)
 {
     if (size > MAXSSIZE)
-        luaM_toobig(L, "string too big");
+        luaM_toobig(L, "string too big", MAXSSIZE);
 
     TString* ts = luaM_newgco(L, TString, sizestring(size), L->activememcat);
     luaC_init(L, ts, LUA_TSTRING);

--- a/VM/src/lstring.cpp
+++ b/VM/src/lstring.cpp
@@ -74,7 +74,7 @@ void luaS_resize(lua_State* L, int newsize)
 static TString* newlstr(lua_State* L, const char* str, size_t l, unsigned int h)
 {
     if (l > MAXSSIZE)
-        luaM_toobig(L);
+        luaM_toobig(L, "string too big");
 
     TString* ts = luaM_newgco(L, TString, sizestring(l), L->activememcat);
     luaC_init(L, ts, LUA_TSTRING);
@@ -101,7 +101,7 @@ static TString* newlstr(lua_State* L, const char* str, size_t l, unsigned int h)
 TString* luaS_bufstart(lua_State* L, size_t size)
 {
     if (size > MAXSSIZE)
-        luaM_toobig(L);
+        luaM_toobig(L, "string too big");
 
     TString* ts = luaM_newgco(L, TString, sizestring(size), L->activememcat);
     luaC_init(L, ts, LUA_TSTRING);

--- a/VM/src/lstring.cpp
+++ b/VM/src/lstring.cpp
@@ -172,7 +172,7 @@ TString* luaS_newexternallstr(lua_State* L, const char* str, size_t l, void* use
     {
         if (free_cb)
             free_cb(L, str, l, userdata);
-        luaM_toobig(L);
+        luaM_toobig(L, "external string too big", MAXSSIZE);
     }
 
     unsigned int h = luaS_hash(str, l);

--- a/VM/src/lstring.cpp
+++ b/VM/src/lstring.cpp
@@ -74,7 +74,7 @@ void luaS_resize(lua_State* L, int newsize)
 static TString* newlstr(lua_State* L, const char* str, size_t l, unsigned int h)
 {
     if (l > MAXSSIZE)
-        luaM_toobig(L, "string too big (exceeds maximum of 1GiB)");
+        luaM_toobig(L, "string too big");
 
     TString* ts = luaM_newgco(L, TString, sizestring(l), L->activememcat);
     luaC_init(L, ts, LUA_TSTRING);
@@ -101,7 +101,7 @@ static TString* newlstr(lua_State* L, const char* str, size_t l, unsigned int h)
 TString* luaS_bufstart(lua_State* L, size_t size)
 {
     if (size > MAXSSIZE)
-        luaM_toobig(L, "string too big (exceeds maximum of 1GiB)");
+        luaM_toobig(L, "string too big");
 
     TString* ts = luaM_newgco(L, TString, sizestring(size), L->activememcat);
     luaC_init(L, ts, LUA_TSTRING);

--- a/VM/src/ludata.cpp
+++ b/VM/src/ludata.cpp
@@ -10,7 +10,7 @@
 Udata* luaU_newudata(lua_State* L, size_t s, int tag)
 {
     if (s > INT_MAX - sizeof(Udata))
-        luaM_toobig(L);
+        luaM_toobig(L, "userdata too big");
     Udata* u = luaM_newgco(L, Udata, sizeudata(s), L->activememcat);
     luaC_init(L, u, LUA_TUSERDATA);
     u->len = int(s);

--- a/VM/src/ludata.cpp
+++ b/VM/src/ludata.cpp
@@ -10,7 +10,7 @@
 Udata* luaU_newudata(lua_State* L, size_t s, int tag)
 {
     if (s > INT_MAX - sizeof(Udata))
-        luaM_toobig(L, "userdata too big");
+        luaM_toobig(L, "userdata too big (exceeds maximum of ~2GiB)");
     Udata* u = luaM_newgco(L, Udata, sizeudata(s), L->activememcat);
     luaC_init(L, u, LUA_TUSERDATA);
     u->len = int(s);

--- a/VM/src/ludata.cpp
+++ b/VM/src/ludata.cpp
@@ -7,10 +7,12 @@
 
 #include <string.h>
 
+#define MAXUSIZE (INT_MAX - sizeof(Udata))
+
 Udata* luaU_newudata(lua_State* L, size_t s, int tag)
 {
-    if (s > INT_MAX - sizeof(Udata))
-        luaM_toobig(L, "userdata too big");
+    if (s > MAXUSIZE)
+        luaM_toobig(L, "userdata too big", MAXUSIZE);
     Udata* u = luaM_newgco(L, Udata, sizeudata(s), L->activememcat);
     luaC_init(L, u, LUA_TUSERDATA);
     u->len = int(s);

--- a/VM/src/ludata.cpp
+++ b/VM/src/ludata.cpp
@@ -10,7 +10,7 @@
 Udata* luaU_newudata(lua_State* L, size_t s, int tag)
 {
     if (s > INT_MAX - sizeof(Udata))
-        luaM_toobig(L, "userdata too big (exceeds maximum of ~2GiB)");
+        luaM_toobig(L, "userdata too big");
     Udata* u = luaM_newgco(L, Udata, sizeudata(s), L->activememcat);
     luaC_init(L, u, LUA_TUSERDATA);
     u->len = int(s);

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -2397,7 +2397,7 @@ TEST_CASE("NewUserdataOverflow")
     );
 
     CHECK(lua_pcall(L, 0, 0, 0) == LUA_ERRRUN);
-    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: userdata too big") == 0);
+    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: userdata too big (exceeds maximum of ~2GiB)") == 0);
 }
 
 TEST_CASE("SandboxWithoutLibs")

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -2397,7 +2397,7 @@ TEST_CASE("NewUserdataOverflow")
     );
 
     CHECK(lua_pcall(L, 0, 0, 0) == LUA_ERRRUN);
-    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: userdata too big (exceeds maximum of ~2GiB)") == 0);
+    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: userdata too big") == 0);
 }
 
 TEST_CASE("SandboxWithoutLibs")

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -2397,7 +2397,7 @@ TEST_CASE("NewUserdataOverflow")
     );
 
     CHECK(lua_pcall(L, 0, 0, 0) == LUA_ERRRUN);
-    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: block too big") == 0);
+    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: userdata too big") == 0);
 }
 
 TEST_CASE("SandboxWithoutLibs")

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -2397,7 +2397,7 @@ TEST_CASE("NewUserdataOverflow")
     );
 
     CHECK(lua_pcall(L, 0, 0, 0) == LUA_ERRRUN);
-    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: userdata too big (exceeds maximum of 2147483623 bytes)") == 0);
+    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: userdata too big (exceeds maximum of 2.00 GiB)") == 0);
 }
 
 TEST_CASE("SandboxWithoutLibs")

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -2397,7 +2397,7 @@ TEST_CASE("NewUserdataOverflow")
     );
 
     CHECK(lua_pcall(L, 0, 0, 0) == LUA_ERRRUN);
-    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: userdata too big") == 0);
+    CHECK(strcmp(lua_tostring(L, -1), "memory allocation error: userdata too big (exceeds maximum of 2147483623 bytes)") == 0);
 }
 
 TEST_CASE("SandboxWithoutLibs")

--- a/tests/Frontend.test.cpp
+++ b/tests/Frontend.test.cpp
@@ -938,15 +938,10 @@ TEST_CASE_FIXTURE(FrontendFixture, "it_should_be_safe_to_stringify_errors_when_f
     // It could segfault, or you could see weird type names like the empty string or <VALUELESS BY EXCEPTION>
     if (!FFlag::DebugLuauForceOldSolver)
     {
-        CHECK_EQ(
-            "Table type '{ count: string }' not compatible with type '{ Count: number }' because the former is missing field 'Count'",
-            toString(result.errors[0])
-        );
+        CHECK_EQ("required field 'Count' not found in type '{ count: string }' from expected type '{ Count: number }'", toString(result.errors[0]));
     }
     else
-        REQUIRE_EQ(
-            "Table type 'a' not compatible with type '{ Count: number }' because the former is missing field 'Count'", toString(result.errors[0])
-        );
+        REQUIRE_EQ("required field 'Count' not found in type 'a' from expected type '{ Count: number }'", toString(result.errors[0]));
 }
 
 TEST_CASE_FIXTURE(FrontendFixture, "trace_requires_in_nonstrict_mode")

--- a/tests/Frontend.test.cpp
+++ b/tests/Frontend.test.cpp
@@ -24,6 +24,7 @@ LUAU_FASTFLAG(LuauExportValueTypecheck)
 LUAU_FASTFLAG(LuauDontBindOptionalGenericToNil)
 LUAU_FASTFLAG(LuauSubtypingMissingPropertiesAsNil)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
+LUAU_FASTFLAG(LuauBetterMissingPropertiesTypeError)
 
 namespace
 {
@@ -923,6 +924,8 @@ TEST_CASE_FIXTURE(FrontendFixture, "discard_type_graphs")
 
 TEST_CASE_FIXTURE(FrontendFixture, "it_should_be_safe_to_stringify_errors_when_full_type_graph_is_discarded")
 {
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
+
     Frontend fe{!FFlag::DebugLuauForceOldSolver ? SolverMode::New : SolverMode::Old, &fileResolver, &configResolver, {false}};
     fileResolver.source["Module/A"] = R"(
         --!strict

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -18,8 +18,8 @@ TEST_SUITE_BEGIN("Linter");
 TEST_CASE_FIXTURE(Fixture, "CleanCode")
 {
     LintResult result = lint(R"(
-function fib(n)
-    return n < 2 and 1 or fib(n-1) + fib(n-2)
+function _fib(n)
+    return n < 2 and 1 or _fib(n-1) + _fib(n-2)
 end
 
 )");
@@ -30,8 +30,8 @@ end
 TEST_CASE_FIXTURE(Fixture, "type_function_fully_reduces")
 {
     LintResult result = lint(R"(
-function fib(n)
-    return n < 2 or  fib(n-2)
+function _fib(n)
+    return n < 2 or  _fib(n-2)
 end
 
 )");
@@ -420,12 +420,28 @@ end
 function _unusedg()
 end
 
+function meow()
+    meow()
+end
+
+local function nyanya()
+    nyanya()
+end
+
+function kya()
+    kya()
+end
+
+kya()
+
 return foo()
 )");
 
-    REQUIRE(2 == result.warnings.size());
+    REQUIRE(4 == result.warnings.size());
     CHECK_EQ(result.warnings[0].text, "Function 'bar' is never used; prefix with '_' to silence");
     CHECK_EQ(result.warnings[1].text, "Function 'qux' is never used; prefix with '_' to silence");
+    CHECK_EQ(result.warnings[2].text, "Function 'meow' is never used outside its own body; prefix with '_' to silence");
+    CHECK_EQ(result.warnings[3].text, "Function 'nyanya' is never used outside its own body; prefix with '_' to silence");
 }
 
 TEST_CASE_FIXTURE(Fixture, "FunctionUnusedFutureImprovement")

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -9,6 +9,7 @@
 
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauDeprecatedAttributeOnAnonymousFunctions)
+LUAU_FASTFLAG(LuauFunctionUnusedRecursiveLinting)
 
 using namespace Luau;
 
@@ -401,6 +402,8 @@ local _Roact = require(game.Packages.Roact)
 
 TEST_CASE_FIXTURE(Fixture, "FunctionUnused")
 {
+    ScopedFastFlag sff{FFlag::LuauFunctionUnusedRecursiveLinting, true};
+
     LintResult result = lint(R"(
 function bar()
 end

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -425,6 +425,46 @@ return foo()
     CHECK_EQ(result.warnings[1].text, "Function 'qux' is never used; prefix with '_' to silence");
 }
 
+TEST_CASE_FIXTURE(Fixture, "FunctionUnusedFutureImprovement")
+{
+    ScopedFastFlag sff{FFlag::LuauFunctionUnusedRecursiveLinting, true};
+
+    LintResult result = lint(R"(
+-- note: ideally, these would both give warnings, but currently neither of them do (https://github.com/luau-lang/luau/pull/2553/changes#r3738290571)
+
+purr = function(n)
+    return if n < 0 then 1 else n * purr(n - 1)
+end
+
+local hiss
+hiss = function(n)
+    return if n < 0 then 1 else n * hiss(n - 1)
+end
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
+TEST_CASE_FIXTURE(Fixture, "FunctionUnusedRuntimeChange")
+{
+    ScopedFastFlag sff{FFlag::LuauFunctionUnusedRecursiveLinting, true};
+
+    LintResult result = lint(R"(
+-- note: ideally, these would both give warnings, but currently neither of them do (https://github.com/luau-lang/luau/pull/2553/changes#r3738290571)
+
+purr = function(n)
+    return if n < 0 then 1 else n * purr(n - 1)
+end
+
+local hiss
+hiss = function(n)
+    return if n < 0 then 1 else n * hiss(n - 1)
+end
+)");
+
+    REQUIRE(0 == result.warnings.size());
+}
+
 TEST_CASE_FIXTURE(Fixture, "UnreachableCodeBasic")
 {
     LintResult result = lint(R"(

--- a/tests/TypeInfer.aliases.test.cpp
+++ b/tests/TypeInfer.aliases.test.cpp
@@ -14,6 +14,7 @@ LUAU_FASTFLAG(LuauDisallowRedefiningBuiltinTypes)
 LUAU_FASTFLAG(LuauAvoidCascadingRecursiveConstraintViolationError)
 LUAU_FASTFLAG(LuauFixInfiniteTypeRedundantBind)
 LUAU_FASTFLAG(LuauDoNotEmplaceAnnotatedType)
+LUAU_FASTFLAG(LuauBetterPackAndVariadicMismatchErrors)
 
 TEST_SUITE_BEGIN("TypeAliases");
 
@@ -108,6 +109,7 @@ TEST_CASE_FIXTURE(Fixture, "mismatched_generic_type_param")
 {
     // We erroneously report an extra error in this case when the new solver is enabled.
     DOES_NOT_PASS_NEW_SOLVER_GUARD();
+    ScopedFastFlag betterErrors{FFlag::LuauBetterPackAndVariadicMismatchErrors, true};
 
     CheckResult result = check(R"(
         type T<A> = (A...) -> ()
@@ -116,13 +118,15 @@ TEST_CASE_FIXTURE(Fixture, "mismatched_generic_type_param")
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(
         toString(result.errors[0]) ==
-        "Generic type 'A' is used as a variadic type parameter; consider changing 'A' to 'A...' in the generic argument list"
+        "Generic type 'A' is used like a generic pack; consider changing it to 'A...' in the generic argument list or using it as 'A' or '...A'"
     );
     CHECK(result.errors[0].location == Location{{1, 21}, {1, 25}});
 }
 
 TEST_CASE_FIXTURE(Fixture, "mismatched_generic_pack_type_param")
 {
+    ScopedFastFlag betterErrors{FFlag::LuauBetterPackAndVariadicMismatchErrors, true};
+
     CheckResult result = check(R"(
         type T<A...> = (A) -> ()
     )");
@@ -130,7 +134,7 @@ TEST_CASE_FIXTURE(Fixture, "mismatched_generic_pack_type_param")
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     CHECK(
         toString(result.errors[0]) ==
-        "Variadic type parameter 'A...' is used as a regular generic type; consider changing 'A...' to 'A' in the generic argument list"
+        "Generic pack 'A...' is used like a generic type; consider changing it to 'A' in the generic argument list or using it as 'A...'"
     );
     CHECK(result.errors[0].location == Location{{1, 24}, {1, 25}});
 }

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -2303,7 +2303,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "param_1_and_2_both_takes_the_same_generic_bu
         const std::string expected = R"(Expected this to be 'vec2?', but got '{| x: number |}'
 caused by:
   None of the union options are compatible. For example:
-Table type '{| x: number |}' not compatible with type 'vec2' because the former is missing field 'y')";
+required field 'y' not found in type '{| x: number |}' from expected type 'vec2')";
         CHECK_EQ(expected, toString(result.errors[0]));
         CHECK_EQ("Expected this to be 'number', but got 'vec2'", toString(result.errors[1]));
     }

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -25,6 +25,7 @@ LUAU_FASTFLAG(LuauBidirectionalInferenceVariadics)
 LUAU_FASTFLAG(LuauConstraintGraph)
 LUAU_FASTFLAG(LuauBidirectionalInferenceBetterLambdaHandling)
 LUAU_FASTFLAG(LuauHigherOrderGenericInference)
+LUAU_FASTFLAG(LuauBetterMissingPropertiesTypeError)
 
 TEST_SUITE_BEGIN("TypeInferFunctions");
 
@@ -2247,6 +2248,8 @@ TEST_CASE_FIXTURE(Fixture, "function_exprs_are_generalized_at_signature_scope_no
 
 TEST_CASE_FIXTURE(BuiltinsFixture, "param_1_and_2_both_takes_the_same_generic_but_their_arguments_are_incompatible")
 {
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
+
     CheckResult result = check(R"(
         local function foo<a>(x: a, y: a?)
             return x

--- a/tests/TypeInfer.generics.test.cpp
+++ b/tests/TypeInfer.generics.test.cpp
@@ -11,6 +11,7 @@ LUAU_FASTFLAG(LuauInstantiateInSubtyping)
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(DebugLuauAssertOnForcedConstraint)
 LUAU_FASTFLAG(LuauInstantiateFunctionTypeBeforePush)
+LUAU_FASTFLAG(LuauBetterPackAndVariadicMismatchErrors)
 
 using namespace Luau;
 
@@ -2214,7 +2215,11 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "generic_pack_and_variadic_mismatch_error")
 
     CHECK_EQ(toString(res.errors[0]), "Unknown type 'DT'");
     CHECK_EQ(toString(res.errors[1]), "Expected this to be '...V', but got 'T...'; the former is a variadic, "
+<<<<<<< HEAD
         "and the latter is a generic pack; consider changing the generic to 'T', and the variadic parameter to  '...: T'");
+=======
+        "and the latter is a generic pack; consider changing the generic to 'T', and the variadic parameter to  '...: T'.");
+>>>>>>> 3bc7fede (do the thing)
     CHECK_EQ(toString(res.errors[2]), "Expected this to be"
         "\n\t'<DT...>(string, DT...) -> number'"
         "\nbut got"

--- a/tests/TypeInfer.generics.test.cpp
+++ b/tests/TypeInfer.generics.test.cpp
@@ -2192,4 +2192,38 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "cli_185450_instantiate_generics_prior_to_pus
     )"));
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "generic_pack_and_variadic_mismatch_error")
+{
+    ScopedFastFlag betterErrors{FFlag::LuauBetterPackAndVariadicMismatchErrors, true};
+
+    CheckResult res = check(R"(
+        local function _foo<T...>(a: number, ...: T...)
+            local _t = table.pack(...)
+        end
+
+        type fn = <DT...>(b: string, DT...) -> number
+        local _fun: fn = function<FT>(b: string, ...: FT): number
+            return 5
+        end
+
+        type fn2 = <DT>(DT...) -> number
+        local _fun2 = function<FT...>(...: FT)
+        end
+    )");
+    LUAU_REQUIRE_ERROR_COUNT(5, res);
+
+    CHECK_EQ(toString(res.errors[0]), "Unknown type 'DT'");
+    CHECK_EQ(toString(res.errors[1]), "Expected this to be '...V', but got 'T...'; the former is a variadic, "
+        "and the latter is a generic pack; consider changing the generic to 'T', and the variadic parameter to  '...: T'");
+    CHECK_EQ(toString(res.errors[2]), "Expected this to be"
+        "\n\t'<DT...>(string, DT...) -> number'"
+        "\nbut got"
+        "\n\t'<FT>(string, ...FT) -> number'; "
+        "\nit takes a tail of `...FT` in the latter type and `DT...` in the former type, and `...FT` is not a supertype of `DT...`; "
+        "the former type has a generic pack, and the latter type has a variadic, consider changing the former generic to `DT` or the latter generic to `FT...`"
+    );
+    CHECK_EQ(toString(res.errors[3]), "Generic type 'DT' is used like a generic pack; consider changing it to 'DT...' in the generic argument list or using it as 'DT' or '...DT'");
+    CHECK_EQ(toString(res.errors[4]), "Generic pack 'FT...' is used like a generic type; consider changing it to 'FT' in the generic argument list or using it as 'FT...'");
+}
+
 TEST_SUITE_END();

--- a/tests/TypeInfer.generics.test.cpp
+++ b/tests/TypeInfer.generics.test.cpp
@@ -2215,11 +2215,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "generic_pack_and_variadic_mismatch_error")
 
     CHECK_EQ(toString(res.errors[0]), "Unknown type 'DT'");
     CHECK_EQ(toString(res.errors[1]), "Expected this to be '...V', but got 'T...'; the former is a variadic, "
-<<<<<<< HEAD
-        "and the latter is a generic pack; consider changing the generic to 'T', and the variadic parameter to  '...: T'");
-=======
         "and the latter is a generic pack; consider changing the generic to 'T', and the variadic parameter to  '...: T'.");
->>>>>>> 3bc7fede (do the thing)
     CHECK_EQ(toString(res.errors[2]), "Expected this to be"
         "\n\t'<DT...>(string, DT...) -> number'"
         "\nbut got"

--- a/tests/TypeInfer.singletons.test.cpp
+++ b/tests/TypeInfer.singletons.test.cpp
@@ -391,8 +391,7 @@ TEST_CASE_FIXTURE(Fixture, "table_properties_type_error_escapes")
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
 
-    const std::string expected =
-        R"(Table type '{ ["\n"]: number }' not compatible with type '{ ["<>"]: number }' because the former is missing field '<>')";
+    const std::string expected = R"(required field '<>' not found in type '{ ["\n"]: number }' from expected type '{ ["<>"]: number }')";
     CHECK(expected == toString(result.errors[0]));
 }
 
@@ -409,15 +408,14 @@ local a: Animal = { tag = 'cat', cafood = 'something' }
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     if (!FFlag::DebugLuauForceOldSolver)
         CHECK(
-            R"(Table type '{ cafood: string, tag: "cat" }' not compatible with type 'Cat' because the former is missing field 'catfood')" ==
-            toString(result.errors[0])
+            R"(required field 'catfood' not found in type '{ cafood: string, tag: "cat" }' from expected type 'Cat')" == toString(result.errors[0])
         );
     else
     {
         const std::string expected = R"(Expected this to be 'Cat | Dog', but got 'a'
 caused by:
   None of the union options are compatible. For example:
-Table type 'a' not compatible with type 'Cat' because the former is missing field 'catfood')";
+required field 'catfood' not found in type 'a' from expected type 'Cat')";
         CHECK_EQ(expected, toString(result.errors[0]));
     }
 }
@@ -436,8 +434,7 @@ local a: Result = { success = false, result = 'something' }
     if (!FFlag::DebugLuauForceOldSolver)
     {
         CHECK_EQ(
-            "Table type '{ result: string, success: false }' not compatible with type 'Bad' because the former is missing field 'error'",
-            toString(result.errors[0])
+            "required field 'error' not found in type '{ result: string, success: false }' from expected type 'Bad'", toString(result.errors[0])
         );
     }
     else
@@ -445,7 +442,7 @@ local a: Result = { success = false, result = 'something' }
         const std::string expected = R"(Expected this to be 'Bad | Good', but got 'a'
 caused by:
   None of the union options are compatible. For example:
-Table type 'a' not compatible with type 'Bad' because the former is missing field 'error')";
+required field 'error' not found in type 'a' from expected type 'Bad')";
         CHECK_EQ(expected, toString(result.errors[0]));
     }
 }
@@ -466,8 +463,7 @@ TEST_CASE_FIXTURE(Fixture, "parametric_tagged_union_alias")
     LUAU_REQUIRE_ERROR_COUNT(1, result);
 
     CHECK_EQ(
-        "Table type '{ result: string, success: false }' not compatible with type 'Err<number>' because the former is missing field 'error'",
-        toString(result.errors[0])
+        "required field 'error' not found in type '{ result: string, success: false }' from expected type 'Err<number>'", toString(result.errors[0])
     );
 }
 

--- a/tests/TypeInfer.singletons.test.cpp
+++ b/tests/TypeInfer.singletons.test.cpp
@@ -10,6 +10,7 @@ using namespace Luau;
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauConstraintGraph)
 LUAU_FASTFLAG(LuauDropUnionSubtypeReasoning)
+LUAU_FASTFLAG(LuauBetterMissingPropertiesTypeError)
 
 TEST_SUITE_BEGIN("TypeSingletons");
 
@@ -382,6 +383,7 @@ TEST_CASE_FIXTURE(Fixture, "indexer_can_be_union_of_singletons")
 TEST_CASE_FIXTURE(Fixture, "table_properties_type_error_escapes")
 {
     ScopedFastFlag sff{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
 
     CheckResult result = check(R"(
         --!strict
@@ -397,6 +399,8 @@ TEST_CASE_FIXTURE(Fixture, "table_properties_type_error_escapes")
 
 TEST_CASE_FIXTURE(Fixture, "error_detailed_tagged_union_mismatch_string")
 {
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
+
     CheckResult result = check(R"(
 type Cat = { tag: 'cat', catfood: string }
 type Dog = { tag: 'dog', dogfood: string }
@@ -422,6 +426,8 @@ required field 'catfood' not found in type 'a' from expected type 'Cat')";
 
 TEST_CASE_FIXTURE(Fixture, "error_detailed_tagged_union_mismatch_bool")
 {
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
+
     CheckResult result = check(R"(
 type Good = { success: true, result: string }
 type Bad = { success: false, error: string }
@@ -450,6 +456,7 @@ required field 'error' not found in type 'a' from expected type 'Bad')";
 TEST_CASE_FIXTURE(Fixture, "parametric_tagged_union_alias")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
 
     CheckResult result = check(R"(
         type Ok<T> = {success: true, result: T}

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -2625,7 +2625,7 @@ local y: number = tmp.p.y
         const std::string expected = R"(Expected this to be exactly 'HasSuper', but got 'tmp'
 caused by:
   Property 'p' is not compatible.
-Table type '{| x: number, y: number |}' not compatible with type 'Super' because the former has extra field 'y')";
+extra field 'y' found in type '{| x: number, y: number |}' from expected type 'Super')";
         CHECK_EQ(expected, toString(result.errors[0]));
     }
 }
@@ -3711,14 +3711,14 @@ TEST_CASE_FIXTURE(Fixture, "scalar_is_not_a_subtype_of_a_compatible_polymorphic_
             R"(Expected this to be 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}', but got 'string'
 caused by:
   The given type's metatable does not satisfy the requirements.
-Table type 'typeof(string)' not compatible with type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
+required field 'absolutely_no_scalar_has_this_method' not found in type 'typeof(string)' from expected type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}')";
         CHECK_EQ(expected1, toString(result.errors[0]));
 
         const std::string expected2 =
             R"(Expected this to be 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}', but got '"bar"'
 caused by:
   The given type's metatable does not satisfy the requirements.
-Table type 'typeof(string)' not compatible with type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
+required field 'absolutely_no_scalar_has_this_method' not found in type 'typeof(string)' from expected type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}')";
         CHECK_EQ(expected2, toString(result.errors[1]));
 
         const std::string expected3 = R"(Expected this to be
@@ -3730,7 +3730,7 @@ caused by:
 Expected this to be 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}', but got '"bar"'
 caused by:
   The given type's metatable does not satisfy the requirements.
-Table type 'typeof(string)' not compatible with type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
+required field 'absolutely_no_scalar_has_this_method' not found in type 'typeof(string)' from expected type 't1 where t1 = {- absolutely_no_scalar_has_this_method: (t1) -> (a...) -}')";
         CHECK_EQ(expected3, toString(result.errors[2]));
     }
 }
@@ -3780,7 +3780,7 @@ TEST_CASE_FIXTURE(Fixture, "a_free_shape_cannot_turn_into_a_scalar_if_it_is_not_
             R"(Expected this to be 'string', but got 't1 where t1 = {+ absolutely_no_scalar_has_this_method: (t1) -> (a, b...) +}'
 caused by:
   The given type's metatable does not satisfy the requirements.
-Table type 'typeof(string)' not compatible with type 't1 where t1 = {+ absolutely_no_scalar_has_this_method: (t1) -> (a, b...) +}' because the former is missing field 'absolutely_no_scalar_has_this_method')";
+required field 'absolutely_no_scalar_has_this_method' not found in type 'typeof(string)' from expected type 't1 where t1 = {+ absolutely_no_scalar_has_this_method: (t1) -> (a, b...) +}')";
         CHECK_EQ(expected, toString(result.errors[0]));
 
         CHECK_EQ("<a, b...>(t1) -> string where t1 = {+ absolutely_no_scalar_has_this_method: (t1) -> (a, b...) +}", toString(requireType("f")));
@@ -5708,8 +5708,7 @@ TEST_CASE_FIXTURE(Fixture, "bigger_nested_table_causes_big_type_error")
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
-    std::string expected =
-        R"(Table type '{ path: string, type: "file" }' not compatible with type 'File' because the former is missing field 'name')";
+    std::string expected = R"(required field 'name' not found in type '{ path: string, type: "file" }' from expected type 'File')";
     CHECK_EQ(expected, toString(result.errors[0]));
     CHECK_EQ(result.errors[0].location, Location{{21, 20}, {24, 21}});
 }

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -31,7 +31,6 @@ LUAU_FASTFLAG(LuauReadOnlyIndexers)
 LUAU_FASTFLAG(LuauRemoveConstraintSolverEmplace)
 LUAU_FASTFLAG(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier)
 LUAU_FASTFLAG(LuauBetterMissingPropertiesTypeError)
-LUAU_FASTFLAG(LuauAlwaysIntersectTablesWithTables)
 LUAU_FASTFLAG(LuauIndexerModifierMismatchErrors)
 
 TEST_SUITE_BEGIN("TableTests");
@@ -7358,35 +7357,16 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "table_insert_strings_and_then_concat")
     )"));
 }
 
-TEST_CASE_FIXTURE(BuiltinsFixture, "normalization_always_intersects_table")
-{
-    ScopedFastFlag _{FFlag::LuauAlwaysIntersectTablesWithTables, true};
-
-    LUAU_REQUIRE_NO_ERRORS(check(R"(
-        local tbl = {}
-
-        function tbl:hmm(occlusionMode)
-            if self.activeOcclusionModule and self.activeOcclusionModule:GetOcclusionMode() == occlusionMode then
-            end
-
-            if self.activeOcclusionModule then
-                local newModuleOcclusionMode = self.activeOcclusionModule:GetOcclusionMode()
-                error("CameraScript ActivateOcclusionModule mismatch: ",self.activeOcclusionModule:GetOcclusionMode())
-            end
-        end
-    )"));
-}
-
 TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_mismatch_error")
 {
     DOES_NOT_PASS_OLD_SOLVER_GUARD();
     ScopedFastFlag _[] = {
+        {FFlag::LuauReadOnlyIndexers, true},
         {FFlag::LuauPropertyModifierMismatchErrors, true},
         {FFlag::LuauIndexerModifierMismatchErrors, true},
     };
 
     CheckResult result = check(R"(
-<<<<<<< HEAD
         local function needBoth(_t: { number })
         end
 
@@ -7403,13 +7383,12 @@ TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_and_type_mismatch_error")
 {
     DOES_NOT_PASS_OLD_SOLVER_GUARD();
     ScopedFastFlag _[] = {
+        {FFlag::LuauReadOnlyIndexers, true},
         {FFlag::LuauPropertyModifierMismatchErrors, true},
         {FFlag::LuauIndexerModifierMismatchErrors, true},
     };
 
     CheckResult result = check(R"(
-=======
->>>>>>> b33b0145 (the implement, do)
         local function needBoth(_t: { string })
         end
 
@@ -7418,20 +7397,10 @@ TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_and_type_mismatch_error")
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
-<<<<<<< HEAD
     CHECK_EQ(toString(result.errors[0]), "Expected this to be '{string}', but got '{read number}'; "
         "\nthis is because "
         "\n\t * the indexer is read-only in the latter type, but the former type requires it to be read-write"
         "\n\t * the result of indexing is `number` in the latter type and `string` in the former type, and `number` is not exactly `string`");
-=======
-    CHECK_EQ(toString(result.errors[0]), "Expected this to be"
-        "\n\t'{ x: string }'"
-        "\nbut got"
-        "\n\t'{ read x: number }'; "
-        "\nthis is because "
-        "\n\t* `x` is read-only in the latter type, but the former type requires it to be read-write"
-        "\n\t* accessing `x` results in `number` in the latter type and `string` in the former type, and `number` is not a subtype of `string`");
->>>>>>> b33b0145 (the implement, do)
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -7347,4 +7347,67 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "table_insert_strings_and_then_concat")
     )"));
 }
 
+TEST_CASE_FIXTURE(BuiltinsFixture, "normalization_always_intersects_table")
+{
+    ScopedFastFlag _{FFlag::LuauAlwaysIntersectTablesWithTables, true};
+
+    LUAU_REQUIRE_NO_ERRORS(check(R"(
+        local tbl = {}
+
+        function tbl:hmm(occlusionMode)
+            if self.activeOcclusionModule and self.activeOcclusionModule:GetOcclusionMode() == occlusionMode then
+            end
+
+            if self.activeOcclusionModule then
+                local newModuleOcclusionMode = self.activeOcclusionModule:GetOcclusionMode()
+                error("CameraScript ActivateOcclusionModule mismatch: ",self.activeOcclusionModule:GetOcclusionMode())
+            end
+        end
+    )"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_mismatch_error")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    ScopedFastFlag _[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
+
+    CheckResult result = check(R"(
+        local function needBoth(_t: { number })
+        end
+
+        local read: { read number } = {}
+        needBoth(read)
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    CHECK_EQ(toString(result.errors[0]), "Expected this to be '{number}', but got '{read number}'; "
+        "\nthe indexer is read-only in the latter type, but the former type requires it to be read-write");
+}
+
+TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_and_type_mismatch_error")
+{
+    DOES_NOT_PASS_OLD_SOLVER_GUARD();
+    ScopedFastFlag _[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
+
+    CheckResult result = check(R"(
+        local function needBoth(_t: { string })
+        end
+
+        local read: { read number } = {}
+        needBoth(read)
+    )");
+
+    LUAU_REQUIRE_ERROR_COUNT(1, result);
+    CHECK_EQ(toString(result.errors[0]), "Expected this to be '{string}', but got '{read number}'; "
+        "\nthis is because "
+        "\n\t * the indexer is read-only in the latter type, but the former type requires it to be read-write"
+        "\n\t * the result of indexing is `number` in the latter type and `string` in the former type, and `number` is not exactly `string`");
+}
+
 TEST_SUITE_END();

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -31,6 +31,8 @@ LUAU_FASTFLAG(LuauReadOnlyIndexers)
 LUAU_FASTFLAG(LuauRemoveConstraintSolverEmplace)
 LUAU_FASTFLAG(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier)
 LUAU_FASTFLAG(LuauBetterMissingPropertiesTypeError)
+LUAU_FASTFLAG(LuauAlwaysIntersectTablesWithTables)
+LUAU_FASTFLAG(LuauIndexerModifierMismatchErrors)
 
 TEST_SUITE_BEGIN("TableTests");
 
@@ -4506,7 +4508,10 @@ TEST_CASE_FIXTURE(Fixture, "write_to_unusually_named_read_only_property")
 TEST_CASE_FIXTURE(Fixture, "read_only_property_with_type_mismatch_reports_both_errors")
 {
     DOES_NOT_PASS_OLD_SOLVER_GUARD();
-    ScopedFastFlag sff{FFlag::LuauPropertyModifierMismatchErrors, true};
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
 
     // When a property is both read-only AND has a type mismatch, both issues are reported
     // independently so the user knows they need to fix both.
@@ -4520,13 +4525,16 @@ TEST_CASE_FIXTURE(Fixture, "read_only_property_with_type_mismatch_reports_both_e
 
     const std::string msg = toString(result.errors[0]);
     CHECK(msg.find("accessing `woof` results in `string` in the latter type and `number` in the former type") != std::string::npos);
-    CHECK(msg.find("`woof` is a read-only property in the latter type, but the former type requires a read-write property") != std::string::npos);
+    CHECK(msg.find("`woof` is read-only in the latter type, but the former type requires it to be read-write") != std::string::npos);
 }
 
 TEST_CASE_FIXTURE(Fixture, "read_only_property_subtype_mismatch_error_message")
 {
     DOES_NOT_PASS_OLD_SOLVER_GUARD();
-    ScopedFastFlag sff{FFlag::LuauPropertyModifierMismatchErrors, true};
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
 
     CheckResult result = check(R"(
         local function f(t: { read woof: number }): { woof: number }
@@ -4541,14 +4549,17 @@ TEST_CASE_FIXTURE(Fixture, "read_only_property_subtype_mismatch_error_message")
         "\t'{ woof: number }'\n"
         "but got\n"
         "\t'{ read woof: number }'; \n"
-        "`woof` is a read-only property in the latter type, but the former type requires a read-write property" == toString(result.errors[0])
+        "`woof` is read-only in the latter type, but the former type requires it to be read-write" == toString(result.errors[0])
     );
 }
 
 TEST_CASE_FIXTURE(Fixture, "write_only_property_subtype_mismatch_error_message")
 {
     DOES_NOT_PASS_OLD_SOLVER_GUARD();
-    ScopedFastFlag sff{FFlag::LuauPropertyModifierMismatchErrors, true};
+    ScopedFastFlag sff[] = {
+        {FFlag::LuauPropertyModifierMismatchErrors, true},
+        {FFlag::LuauIndexerModifierMismatchErrors, true},
+    };
 
     CheckResult result = check(R"(
         local function f(t: { write woof: number }): { woof: number }
@@ -4563,7 +4574,7 @@ TEST_CASE_FIXTURE(Fixture, "write_only_property_subtype_mismatch_error_message")
         "\t'{ woof: number }'\n"
         "but got\n"
         "\t'{ write woof: number }'; \n"
-        "`woof` is a write-only property in the latter type, but the former type requires a read-write property" == toString(result.errors[0])
+        "`woof` is write-only in the latter type, but the former type requires it to be read-write" == toString(result.errors[0])
     );
 }
 
@@ -7375,6 +7386,7 @@ TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_mismatch_error")
     };
 
     CheckResult result = check(R"(
+<<<<<<< HEAD
         local function needBoth(_t: { number })
         end
 
@@ -7396,6 +7408,8 @@ TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_and_type_mismatch_error")
     };
 
     CheckResult result = check(R"(
+=======
+>>>>>>> b33b0145 (the implement, do)
         local function needBoth(_t: { string })
         end
 
@@ -7404,10 +7418,20 @@ TEST_CASE_FIXTURE(Fixture, "readonly_indexer_access_and_type_mismatch_error")
     )");
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
+<<<<<<< HEAD
     CHECK_EQ(toString(result.errors[0]), "Expected this to be '{string}', but got '{read number}'; "
         "\nthis is because "
         "\n\t * the indexer is read-only in the latter type, but the former type requires it to be read-write"
         "\n\t * the result of indexing is `number` in the latter type and `string` in the former type, and `number` is not exactly `string`");
+=======
+    CHECK_EQ(toString(result.errors[0]), "Expected this to be"
+        "\n\t'{ x: string }'"
+        "\nbut got"
+        "\n\t'{ read x: number }'; "
+        "\nthis is because "
+        "\n\t* `x` is read-only in the latter type, but the former type requires it to be read-write"
+        "\n\t* accessing `x` results in `number` in the latter type and `string` in the former type, and `number` is not a subtype of `string`");
+>>>>>>> b33b0145 (the implement, do)
 }
 
 TEST_SUITE_END();

--- a/tests/TypeInfer.tables.test.cpp
+++ b/tests/TypeInfer.tables.test.cpp
@@ -29,6 +29,7 @@ LUAU_FASTFLAG(LuauPropertyModifierMismatchErrors)
 LUAU_FASTFLAG(LuauReadOnlyIndexers)
 LUAU_FASTFLAG(LuauRemoveConstraintSolverEmplace)
 LUAU_FASTFLAG(LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier)
+LUAU_FASTFLAG(LuauBetterMissingPropertiesTypeError)
 
 TEST_SUITE_BEGIN("TableTests");
 
@@ -2597,6 +2598,8 @@ a.p = { x = 9 }
 
 TEST_CASE_FIXTURE(Fixture, "explicitly_typed_table_error")
 {
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
+
     CheckResult result = check(R"(
 --!strict
 type Super = { x : number }
@@ -3666,6 +3669,8 @@ TEST_CASE_FIXTURE(Fixture, "scalar_is_a_subtype_of_a_compatible_polymorphic_shap
 
 TEST_CASE_FIXTURE(Fixture, "scalar_is_not_a_subtype_of_a_compatible_polymorphic_shape_type")
 {
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
+
     CheckResult result = check(R"(
         local function f(s)
             return s:absolutely_no_scalar_has_this_method()
@@ -3753,6 +3758,8 @@ TEST_CASE_FIXTURE(Fixture, "a_free_shape_can_turn_into_a_scalar_if_it_is_compati
 
 TEST_CASE_FIXTURE(Fixture, "a_free_shape_cannot_turn_into_a_scalar_if_it_is_not_compatible")
 {
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
+
     CheckResult result = check(R"(
         local function f(s): string
             local foo = s:absolutely_no_scalar_has_this_method()
@@ -5676,6 +5683,7 @@ TEST_CASE_FIXTURE(Fixture, "deeply_nested_classish_inference")
 TEST_CASE_FIXTURE(Fixture, "bigger_nested_table_causes_big_type_error")
 {
     ScopedFastFlag _{FFlag::DebugLuauForceOldSolver, false};
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
 
     auto result = check(R"(
         type File = {

--- a/tests/TypeInfer.test.cpp
+++ b/tests/TypeInfer.test.cpp
@@ -1195,7 +1195,7 @@ TEST_CASE_FIXTURE(Fixture, "cli_50041_committing_txnlog_in_apollo_client_error")
             "'FieldSpecifier'"
             "\ncaused by:\n"
             "  Not all intersection parts are compatible.\n"
-            "Table type 'FieldSpecifier' not compatible with type '{ from: number? }' because the former has extra field 'fieldName'";
+            "extra field 'fieldName' found in type 'FieldSpecifier' from expected type '{ from: number? }'";
         CHECK_EQ(expected, toString(result.errors[0]));
     }
     else

--- a/tests/TypeInfer.test.cpp
+++ b/tests/TypeInfer.test.cpp
@@ -34,6 +34,7 @@ LUAU_FASTFLAG(LuauSubtypingMissingPropertiesAsNil)
 LUAU_FASTFLAG(LuauImproveUniqueTableWidthSubtyping)
 LUAU_FASTFLAG(LuauDontBindOptionalGenericToNil)
 LUAU_FASTFLAG(LuauBidirectionalInferenceSimplifyTables)
+LUAU_FASTFLAG(LuauBetterMissingPropertiesTypeError)
 
 using namespace Luau;
 
@@ -1142,6 +1143,7 @@ end
 TEST_CASE_FIXTURE(Fixture, "cli_50041_committing_txnlog_in_apollo_client_error")
 {
     DOES_NOT_PASS_NEW_SOLVER_GUARD();
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
 
     CheckResult result = check(R"(
         --!strict

--- a/tests/TypeInfer.unionTypes.test.cpp
+++ b/tests/TypeInfer.unionTypes.test.cpp
@@ -547,7 +547,7 @@ end
         CHECK_EQ(toString(result.errors[0]), R"(Expected this to be '{ w: number }', but got 'X | Y | Z'
 caused by:
   Not all union options are compatible.
-Table type 'X' not compatible with type '{ w: number }' because the former is missing field 'w')");
+required field 'w' not found in type 'X' from expected type '{ w: number }')");
     }
 }
 
@@ -582,13 +582,13 @@ local a: X? = { w = 4 }
 
     LUAU_REQUIRE_ERROR_COUNT(1, result);
     if (!FFlag::DebugLuauForceOldSolver)
-        CHECK("Table type '{ w: number }' not compatible with type 'X' because the former is missing field 'x'" == toString(result.errors[0]));
+        CHECK("required field 'x' not found in type '{ w: number }' from expected type 'X'" == toString(result.errors[0]));
     else
     {
         const std::string expected = R"(Expected this to be 'X?', but got 'a'
 caused by:
   None of the union options are compatible. For example:
-Table type 'a' not compatible with type 'X' because the former is missing field 'x')";
+required field 'x' not found in type 'a' from expected type 'X')";
         CHECK_EQ(expected, toString(result.errors[0]));
     }
 }
@@ -1116,7 +1116,7 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "oss_2025")
 
         local baz: a? = bar.test
 
-        table.insert(foo, bar) 
+        table.insert(foo, bar)
     )"));
 }
 

--- a/tests/TypeInfer.unionTypes.test.cpp
+++ b/tests/TypeInfer.unionTypes.test.cpp
@@ -12,6 +12,7 @@ LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauPropagateFreeTypesIntoUnionAndIntersectionBounds)
 LUAU_FASTFLAG(LuauSubtypeUnionsTogether)
 LUAU_FASTFLAG(LuauDropUnionSubtypeReasoning)
+LUAU_FASTFLAG(LuauBetterMissingPropertiesTypeError)
 
 TEST_SUITE_BEGIN("UnionTypes");
 
@@ -517,6 +518,8 @@ local oh : boolean = t.y
 
 TEST_CASE_FIXTURE(Fixture, "error_detailed_union_part")
 {
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
+
     CheckResult result = check(R"(
 type X = { x: number }
 type Y = { y: number }
@@ -574,6 +577,8 @@ TEST_CASE_FIXTURE(Fixture, "error_detailed_union_all")
 
 TEST_CASE_FIXTURE(Fixture, "error_detailed_optional")
 {
+    ScopedFastFlag sff{FFlag::LuauBetterMissingPropertiesTypeError, true};
+
     CheckResult result = check(R"(
 type X = { x: number }
 


### PR DESCRIPTION
This PR merges several PRs from upstream that aim to improve type error messages. 
In particular, the following PRs were merged:
- (improve missing type properties) https://github.com/luau-lang/luau/pull/2558
- (unused function lint for recursive functions) https://github.com/luau-lang/luau/pull/2553
- (improve "block too big" errors) https://github.com/luau-lang/luau/pull/2579
- (improve error messages for generic pack and variadic type mismatches) https://github.com/luau-lang/luau/pull/2504 
- (fix read-only indexer access mismatch errors) https://github.com/luau-lang/luau/pull/2611