### PR TITLE
compare isC != 0 instead of isC == 1 to fix segfault with ncg and fat c closures

### DIFF
--- a/CodeGen/src/EmitInstructionX64.cpp
+++ b/CodeGen/src/EmitInstructionX64.cpp
@@ -40,8 +40,8 @@ void emitInstCall(IrRegAllocX64& regs, AssemblyBuilderX64& build, ModuleHelpers&
 
     Label cFuncCall;
 
-    build.test(byte[ccl + offsetof(Closure, isC)], 1);
-    build.jcc(ConditionX64::NotZero, cFuncCall);
+    build.cmp(byte[ccl + offsetof(Closure, isC)], 0);
+    build.jcc(ConditionX64::NotEqual, cFuncCall);
 
     {
         RegisterX64 proto = rcx; // Sync with emitContinueCallInVm

--- a/CodeGen/src/IrLoweringX64.cpp
+++ b/CodeGen/src/IrLoweringX64.cpp
@@ -3671,8 +3671,8 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
     case IrCmd::JUMP_CMP_PROTOID:
     {
         LUAU_ASSERT(OP_A(inst).kind == IrOpKind::Inst);
-        build.cmp(byte[regOp(OP_A(inst)) + offsetof(Closure, isC)], 1);
-        build.jcc(ConditionX64::Equal, labelOp(OP_D(inst)));
+        build.cmp(byte[regOp(OP_A(inst)) + offsetof(Closure, isC)], 0);
+        build.jcc(ConditionX64::NotEqual, labelOp(OP_D(inst)));
         {
             ScopedRegX64 tmp{regs, SizeX64::qword};
             build.mov(tmp.reg, qword[regOp(OP_A(inst)) + offsetof(Closure, l.p)]);


### PR DESCRIPTION
Found w/ mluau segfault 