### PR TITLE
fix: avoid leaking uninit userdata ptr by explicitly nulling userdata…

### DIFF
--- a/VM/src/lbuffer.cpp
+++ b/VM/src/lbuffer.cpp
@@ -19,6 +19,7 @@ Buffer* luaB_newbuffer(lua_State* L, size_t s)
     b->mode = 0;
     b->free_cb = NULL;
     b->data = b->inline_data;
+    b->userdata = NULL;
     memset(b->data, 0, b->len);
     return b;
 }


### PR DESCRIPTION
… in luaB_newbuffer