### PR TITLE
Fix incorrect mluau/luau maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,8 +9,8 @@
 - LuauExternalString (and DebugLuauAllowNonNullTerminatedStrings for tests): @cheesycod
 - LuauFatCClosure: @cheesycod
 - LuauManagedReferences2: @cheesycod
-- LuauFunctionUnusedRecursiveLinting, LuauBetterPackAndVariadicMismatchErrors, LuauIndexerModifierMismatchErrors, LuauPropertyModifierMismatchErrors: @PhoenixWhitefire (merged from upstream)
-- LuauBetterMissingPropertiesTypeError, LuauFunctionUnusedRecursiveLinting: @nnullcolumn (merged from upstream)
+- LuauFunctionUnusedRecursiveLinting, LuauBetterPackAndVariadicMismatchErrors, LuauIndexerModifierMismatchErrors, LuauPropertyModifierMismatchErrors: @MabMabMabMabMab (undercols) authored by @PhoenixWhitefire (merged from upstream)
+- LuauBetterMissingPropertiesTypeError, LuauFunctionUnusedRecursiveLinting: @MabMabMabMabMab and @deviaze (authored by nnullcolumn, who is not an mluau/luau maintainer; merged from upstream)
 
 ## Other
 


### PR DESCRIPTION
We accidentally listed @nnullcolumn (who is not a mluau/luau contributor) and PhoenixWhitefire (who is an mluau/luau contributor) as maintainers in MAINTAINERS.md. This has been fixed to specify the committer as the maintainer with me taking ownership of the latter as well.