### PR TITLE
Fix LSP crash on function default args and new solver without param annotations

### DIFF
--- a/Analysis/src/ConstraintGenerator.cpp
+++ b/Analysis/src/ConstraintGenerator.cpp
@@ -4112,7 +4112,11 @@ ConstraintGenerator::FunctionSignature ConstraintGenerator::checkFunctionSignatu
             AstExpr* argDefault = fn->argsDefaults.data[i];
             if (argDefault)
             {
-                Inference found = check(signatureScope, argDefault, argTy);
+                std::optional<TypeId> expectedArgTy;
+                if (hasSpecifiedArgTy)
+                    expectedArgTy = argTy;
+
+                Inference found = check(signatureScope, argDefault, expectedArgTy);
 
                 if (hasSpecifiedArgTy)
                     addConstraint(signatureScope, argDefault->location, SubtypeConstraint{found.ty, argTy});

--- a/tests/TypeInfer.functions.test.cpp
+++ b/tests/TypeInfer.functions.test.cpp
@@ -4406,4 +4406,22 @@ TEST_CASE_FIXTURE(Fixture, "default_argument_is_checked_against_parameter_annota
     CHECK(!result.errors.empty());
 }
 
+TEST_CASE_FIXTURE(Fixture, "default_argument_infers_parameter_type_string")
+{
+    // Regression test; lsp used to crash in some cases when type annotations w/ default arg weren't provided
+    ScopedFastFlag sffs[] = {
+        {FFlag::DebugLuauForceOldSolver, false},
+        {FFlag::LuauDefaultArguments, true},
+    };
+
+    CheckResult result = check(R"(
+        local function meow(message = "meow")
+            return message
+        end
+    )");
+
+    LUAU_REQUIRE_NO_ERRORS(result);
+    CHECK_EQ("(string?) -> string", toString(requireType("meow")));
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
As part of the classes impl I noticed with Bottersnike's default args and new solver enabled i get a crash sometimes in lsp.. Hopefully this fixes that.... 