### PR TITLE
proper (hopefully) fix to external buffer ncg

### DIFF
--- a/CodeGen/src/IrLoweringA64.cpp
+++ b/CodeGen/src/IrLoweringA64.cpp
@@ -4215,33 +4215,68 @@ AddressA64 IrLoweringA64::tempAddr(IrOp op, int offset, RegisterA64 tempStorage)
 AddressA64 IrLoweringA64::tempAddrBuffer(IrOp bufferOp, IrOp indexOp, uint8_t tag)
 {
     CODEGEN_ASSERT(tag == LUA_TUSERDATA || tag == LUA_TBUFFER);
-    int dataOffset = tag == LUA_TBUFFER ? offsetof(Buffer, inline_data) : offsetof(Udata, data);
-
-    if (indexOp.kind == IrOpKind::Inst)
+    if (tag == LUA_TBUFFER)
     {
-        CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd));
+        // data may be inline_data (mode 0) or an non-inline (externally owned) pointer (mode 1/2)
+        //
+        // As such, we have to load the data with a extra ldr instruction
+        RegisterA64 dataPtr = regs.allocTemp(KindA64::x);
+        build.ldr(dataPtr, mem(regOp(bufferOp), offsetof(Buffer, data)));
 
-        RegisterA64 temp = regs.allocTemp(KindA64::x);
-        build.add(temp, regOp(bufferOp), regOp(indexOp)); // implicit uxtw
-        return mem(temp, dataOffset);
+        if (indexOp.kind == IrOpKind::Inst)
+        {
+            CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd));
+
+            RegisterA64 temp = regs.allocTemp(KindA64::x);
+            build.add(temp, dataPtr, regOp(indexOp)); // implicit uxtw
+            return mem(temp, 0);
+        }
+        else if (indexOp.kind == IrOpKind::Constant)
+        {
+            // Since the resulting address may be used to load any size, including 1 byte, from an unaligned offset, we are limited by unscaled
+            // encoding
+            if (unsigned(intOp(indexOp)) <= 255)
+                return mem(dataPtr, int(intOp(indexOp)));
+
+            // indexOp can only be negative in dead code (since offsets are checked); this avoids assertion in emitAddOffset
+            if (intOp(indexOp) < 0)
+                return mem(dataPtr, 0);
+
+            RegisterA64 temp = regs.allocTemp(KindA64::x);
+            emitAddOffset(build, temp, dataPtr, size_t(intOp(indexOp)));
+            return mem(temp, 0);
+        }
+
+        CODEGEN_ASSERT(!"Unsupported instruction form");
+        return noreg;
     }
-    else if (indexOp.kind == IrOpKind::Constant)
+    else // LUA_TUSERDATA
     {
-        // Since the resulting address may be used to load any size, including 1 byte, from an unaligned offset, we are limited by unscaled
-        // encoding
-        if (unsigned(intOp(indexOp)) + dataOffset <= 255)
-            return mem(regOp(bufferOp), int(intOp(indexOp) + dataOffset));
+        int dataOffset = offsetof(Udata, data);
+        if (indexOp.kind == IrOpKind::Inst)
+        {
+            CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd));
 
-        // indexOp can only be negative in dead code (since offsets are checked); this avoids assertion in emitAddOffset
-        if (intOp(indexOp) < 0)
-            return mem(regOp(bufferOp), dataOffset);
+            RegisterA64 temp = regs.allocTemp(KindA64::x);
+            build.add(temp, regOp(bufferOp), regOp(indexOp)); // implicit uxtw
+            return mem(temp, dataOffset);
+        }
+        else if (indexOp.kind == IrOpKind::Constant)
+        {
+            // Since the resulting address may be used to load any size, including 1 byte, from an unaligned offset, we are limited by unscaled
+            // encoding
+            if (unsigned(intOp(indexOp)) + dataOffset <= 255)
+                return mem(regOp(bufferOp), int(intOp(indexOp) + dataOffset));
 
-        RegisterA64 temp = regs.allocTemp(KindA64::x);
-        emitAddOffset(build, temp, regOp(bufferOp), size_t(intOp(indexOp)));
-        return mem(temp, dataOffset);
-    }
-    else
-    {
+            // indexOp can only be negative in dead code (since offsets are checked); this avoids assertion in emitAddOffset
+            if (intOp(indexOp) < 0)
+                return mem(regOp(bufferOp), dataOffset);
+
+            RegisterA64 temp = regs.allocTemp(KindA64::x);
+            emitAddOffset(build, temp, regOp(bufferOp), size_t(intOp(indexOp)));
+            return mem(temp, dataOffset);
+        }
+
         CODEGEN_ASSERT(!"Unsupported instruction form");
         return noreg;
     }

--- a/CodeGen/src/IrLoweringX64.cpp
+++ b/CodeGen/src/IrLoweringX64.cpp
@@ -4108,21 +4108,44 @@ RegisterX64 IrLoweringX64::regOp(IrOp op)
 OperandX64 IrLoweringX64::bufferAddrOp(IrOp bufferOp, IrOp indexOp, uint8_t tag)
 {
     CODEGEN_ASSERT(tag == LUA_TUSERDATA || tag == LUA_TBUFFER);
-    int dataOffset = tag == LUA_TBUFFER ? offsetof(Buffer, inline_data) : offsetof(Udata, data);
-
-    if (indexOp.kind == IrOpKind::Inst)
+    if (tag == LUA_TBUFFER)
     {
-        CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd)); // Ensure that high register bits are cleared
+        // data may be inline_data (mode 0) or an non-inline (externally owned) pointer (mode 1/2)
+        //
+        // As such, we have to load the data with a extra mov instruction
+        ScopedRegX64 dataPtr{regs, SizeX64::qword};
+        build.mov(dataPtr.reg, qword[regOp(bufferOp) + offsetof(Buffer, data)]);
 
-        return regOp(bufferOp) + qwordReg(regOp(indexOp)) + dataOffset;
-    }
-    else if (indexOp.kind == IrOpKind::Constant)
-    {
-        return regOp(bufferOp) + intOp(indexOp) + dataOffset;
-    }
+        if (indexOp.kind == IrOpKind::Inst)
+        {
+            CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd));
+            return dataPtr.reg + qwordReg(regOp(indexOp));
+        }
+        else if (indexOp.kind == IrOpKind::Constant)
+        {
+            return dataPtr.reg + intOp(indexOp);
+        }
 
-    CODEGEN_ASSERT(!"Unsupported instruction form");
-    return noreg;
+        CODEGEN_ASSERT(!"Unsupported instruction form");
+        return noreg;
+    } 
+    else 
+    { 
+        // LUA_TUSERDATA
+        int dataOffset = offsetof(Udata, data);
+        if (indexOp.kind == IrOpKind::Inst)
+        {
+            CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd)); // Ensure that high register bits are cleared
+            return regOp(bufferOp) + qwordReg(regOp(indexOp)) + dataOffset;
+        }
+        else if (indexOp.kind == IrOpKind::Constant)
+        {
+            return regOp(bufferOp) + intOp(indexOp) + dataOffset;
+        }
+
+        CODEGEN_ASSERT(!"Unsupported instruction form");
+        return noreg;
+    } 
 }
 
 RegisterX64 IrLoweringX64::vecOp(IrOp op, ScopedRegX64& tmp)


### PR DESCRIPTION
Externally allocated buffers do not store data inline to the buffer so CodeGen IR lowering doing ``Buffer+offsetof(Buffer, inline_data)`` is *wrong*. It instead needs to be ``buffer->data`` (that is, a mov/ldr instruction to deref the data ptr, which for normal buffers points to ``buf->inline_data`` but for external buffers points to the externally allocated buffer's pointer