### PR TITLE
table.drop and table.remove lint improvement

### DIFF
--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -215,6 +215,7 @@ declare table: {
     foreachi: <V>({V}, (number, V) -> ()) -> (),
 
     move: <V>(src: {V}, a: number, b: number, t: number, dst: {V}?) -> {V},
+    drop: <V>(t: {V}, value: V, count: number?) -> number,
 
     clear: (table: {}) -> (),
     isfrozen: (t: {}) -> boolean,
@@ -223,7 +224,6 @@ declare table: {
 )BUILTIN_SRC";
 
 static constexpr const char* kBuiltinDefinitionTableDropSrc = R"BUILTIN_SRC(
-    drop: <V>(t: {V}, value: V, count: number?) -> number,
 )BUILTIN_SRC";
 
 static constexpr const char* kBuiltinDefinitionDebugSrc = R"BUILTIN_SRC(
@@ -388,8 +388,6 @@ std::string getBuiltinDefinitionSource()
     result += kBuiltinDefinitionOsSrc;
     result += kBuiltinDefinitionCoroutineSrc;
     result += kBuiltinDefinitionTableSrc;
-    if (FFlag::LuwuTableDrop)
-        result += kBuiltinDefinitionTableDropSrc;
     result += kBuiltinDefinitionDebugSrc;
     result += kBuiltinDefinitionUtf8Src;
     result += kBuiltinDefinitionBufferSrcCore;

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -206,6 +206,7 @@ declare table: {
     sort: <V>(t: {V}, comp: ((V, V) -> boolean)?) -> (),
     create: <V>(count: number, value: V?) -> {V},
     find: <V>(haystack: {V}, needle: V, init: number?) -> number?,
+    drop: <V>(t: {V}, value: V, count: number?) -> number,
 
     unpack: <V>(list: {V}, i: number?, j: number?) -> ...V,
     pack: <V>(...V) -> { n: number, [number]: V },
@@ -215,15 +216,10 @@ declare table: {
     foreachi: <V>({V}, (number, V) -> ()) -> (),
 
     move: <V>(src: {V}, a: number, b: number, t: number, dst: {V}?) -> {V},
-    drop: <V>(t: {V}, value: V, count: number?) -> number,
-
     clear: (table: {}) -> (),
     isfrozen: (t: {}) -> boolean,
 }
 
-)BUILTIN_SRC";
-
-static constexpr const char* kBuiltinDefinitionTableDropSrc = R"BUILTIN_SRC(
 )BUILTIN_SRC";
 
 static constexpr const char* kBuiltinDefinitionDebugSrc = R"BUILTIN_SRC(
@@ -387,7 +383,17 @@ std::string getBuiltinDefinitionSource()
     result += kBuiltinDefinitionMathSrc;
     result += kBuiltinDefinitionOsSrc;
     result += kBuiltinDefinitionCoroutineSrc;
-    result += kBuiltinDefinitionTableSrc;
+
+    std::string tableSrc = kBuiltinDefinitionTableSrc;
+    if (!FFlag::LuwuTableDrop)
+    {
+        std::string dropEntry = "    drop: <V>(t: {V}, value: V, count: number?) -> number,\n";
+        size_t dropPos = tableSrc.find(dropEntry);
+        if (dropPos != std::string::npos)
+            tableSrc.erase(dropPos, dropEntry.size());
+    }
+    result += tableSrc;
+
     result += kBuiltinDefinitionDebugSrc;
     result += kBuiltinDefinitionUtf8Src;
     result += kBuiltinDefinitionBufferSrcCore;

--- a/Analysis/src/EmbeddedBuiltinDefinitions.cpp
+++ b/Analysis/src/EmbeddedBuiltinDefinitions.cpp
@@ -7,6 +7,7 @@ LUAU_FASTFLAG(LuauAllowGlobalDeclarationToBeCalledClass)
 LUAU_FASTFLAG(DebugLuauUserDefinedClasses)
 LUAU_FASTFLAG(LuauUdtfTypeIsSubtypeOf)
 LUAU_FASTFLAG(LuauBufferIsFrozen)
+LUAU_FASTFLAG(LuwuTableDrop)
 
 namespace Luau
 {
@@ -221,6 +222,10 @@ declare table: {
 
 )BUILTIN_SRC";
 
+static constexpr const char* kBuiltinDefinitionTableDropSrc = R"BUILTIN_SRC(
+    drop: <V>(t: {V}, value: V, count: number?) -> number,
+)BUILTIN_SRC";
+
 static constexpr const char* kBuiltinDefinitionDebugSrc = R"BUILTIN_SRC(
 
 declare debug: {
@@ -383,6 +388,8 @@ std::string getBuiltinDefinitionSource()
     result += kBuiltinDefinitionOsSrc;
     result += kBuiltinDefinitionCoroutineSrc;
     result += kBuiltinDefinitionTableSrc;
+    if (FFlag::LuwuTableDrop)
+        result += kBuiltinDefinitionTableDropSrc;
     result += kBuiltinDefinitionDebugSrc;
     result += kBuiltinDefinitionUtf8Src;
     result += kBuiltinDefinitionBufferSrcCore;

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -2866,7 +2866,7 @@ private:
                         *context,
                         LintWarning::Code_TableOperations,
                         args[1]->location,
-                        "Using an optional result as the 2nd argument to `table.remove` may remove the last element when the index is nil; use `table.drop` or check the result instead."
+                        "If this is `nil`, `table.remove` will remove the last element of the array. This is a common mistake--consider using `table.drop` instead, or if order is not important, use a key/value table with `true` values for better performance."
                     );
                 }
             }

--- a/Analysis/src/Linter.cpp
+++ b/Analysis/src/Linter.cpp
@@ -15,6 +15,7 @@
 
 LUAU_FASTINTVARIABLE(LuauSuggestionDistance, 4)
 LUAU_FASTFLAGVARIABLE(LuauFunctionUnusedRecursiveLinting)
+LUAU_FASTFLAGVARIABLE(LuwuTableRemoveFootgunLint)
 
 namespace Luau
 {
@@ -2631,10 +2632,79 @@ public:
 
 private:
     LintContext* context;
+    DenseHashSet<AstLocal*> tableFindResultLocals;
 
     LintTableOperations(LintContext* context)
         : context(context)
     {
+    }
+
+    static bool isTableFindCall(AstExpr* expr)
+    {
+        if (!expr)
+            return false;
+
+        if (AstExprTypeAssertion* typeAssertion = expr->as<AstExprTypeAssertion>())
+            return isTableFindCall(typeAssertion->expr);
+
+        if (AstExprGroup* group = expr->as<AstExprGroup>())
+            return isTableFindCall(group->expr);
+
+        if (AstExprCall* call = expr->as<AstExprCall>())
+        {
+            if (AstExprIndexName* indexName = call->func->as<AstExprIndexName>())
+            {
+                if (indexName->index == "find")
+                {
+                    if (AstExprGlobal* global = indexName->expr->as<AstExprGlobal>())
+                        return global->name == "table";
+                }
+            }
+        }
+
+        return false;
+    }
+
+    bool isTableFindResult(AstExpr* expr)
+    {
+        if (!expr)
+            return false;
+
+        if (AstExprTypeAssertion* typeAssertion = expr->as<AstExprTypeAssertion>())
+            return isTableFindResult(typeAssertion->expr);
+
+        if (AstExprGroup* group = expr->as<AstExprGroup>())
+            return isTableFindResult(group->expr);
+
+        if (isTableFindCall(expr))
+            return true;
+
+        if (AstExprLocal* local = expr->as<AstExprLocal>())
+            return tableFindResultLocals.contains(local->local);
+
+        return false;
+    }
+
+    bool visit(AstStatLocal* node) override
+    {
+        for (size_t i = 0; i < node->vars.size && i < node->values.size; ++i)
+        {
+            if (isTableFindCall(node->values.data[i]))
+                tableFindResultLocals.insert(node->vars.data[i]);
+        }
+
+        return true;
+    }
+
+    bool visit(AstStatAssign* node) override
+    {
+        for (size_t i = 0; i < node->vars.size && i < node->values.size; ++i)
+        {
+            if (AstExprLocal* local = node->vars.data[i]->as<AstExprLocal>(); local && isTableFindCall(node->values.data[i]))
+                tableFindResultLocals.insert(local->local);
+        }
+
+        return true;
     }
 
     bool visit(AstExprUnary* node) override
@@ -2759,6 +2829,47 @@ private:
                     "table.remove will remove the value before the last element, which is likely a bug; consider removing the second argument or "
                     "wrap it in parentheses to silence"
                 );
+
+            // table.remove(t, <optional number expression>) -- common footgun when passing table.find
+            if (FFlag::LuwuTableRemoveFootgunLint && !args[1]->is<AstExprConstantNil>())
+            {
+                bool warnForOptionalNumber = isTableFindResult(args[1]);
+
+                if (!warnForOptionalNumber)
+                {
+                    if (std::optional<TypeId> ty = context->getType(args[1]))
+                    {
+                        TypeId t = follow(*ty);
+
+                        bool hasNumber = false;
+                        if (isNumber(t))
+                            hasNumber = true;
+                        else if (const UnionType* ut = get<UnionType>(t))
+                        {
+                            for (TypeId part : ut->options)
+                            {
+                                if (isNumber(part))
+                                {
+                                    hasNumber = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        warnForOptionalNumber = isOptional(t) && hasNumber;
+                    }
+                }
+
+                if (warnForOptionalNumber)
+                {
+                    emitWarning(
+                        *context,
+                        LintWarning::Code_TableOperations,
+                        args[1]->location,
+                        "Using an optional result as the 2nd argument to `table.remove` may remove the last element when the index is nil; use `table.drop` or check the result instead."
+                    );
+                }
+            }
         }
 
         if (func->index == "move" && node->args.size >= 4)

--- a/VM/src/ltablib.cpp
+++ b/VM/src/ltablib.cpp
@@ -558,11 +558,8 @@ static int tdrop(lua_State* L)
 
     int n = lua_objlen(L, 1);
     int maxRemoved = luaL_optinteger(L, 3, INT_MAX);
-    if (maxRemoved <= 0)
-    {
-        lua_pushinteger(L, 0);
-        return 1;
-    }
+    if (!lua_isnoneornil(L, 3))
+        luaL_argcheck(L, maxRemoved > 0, 3, "count must be greater than 0");
 
     LuaTable* t = hvalue(L->base);
     if (t->readonly)
@@ -663,15 +660,31 @@ static const luaL_Reg tab_funcs[] = {
     {NULL, NULL},
 };
 
+static const luaL_Reg tab_funcs_with_drop[] = {
+    {"concat", tconcat},
+    {"foreach", foreach},
+    {"foreachi", foreachi},
+    {"getn", getn},
+    {"maxn", maxn},
+    {"insert", tinsert},
+    {"remove", tremove},
+    {"sort", tsort},
+    {"pack", tpack},
+    {"unpack", tunpack},
+    {"move", tmove},
+    {"create", tcreate},
+    {"find", tfind},
+    {"drop", tdrop},
+    {"clear", tclear},
+    {"freeze", tfreeze},
+    {"isfrozen", tisfrozen},
+    {"clone", tclone},
+    {NULL, NULL},
+};
+
 int luaopen_table(lua_State* L)
 {
-    luaL_register(L, LUA_TABLIBNAME, tab_funcs);
-
-    if (FFlag::LuwuTableDrop)
-    {
-        lua_pushcfunction(L, tdrop, "drop");
-        lua_setfield(L, -2, "drop");
-    }
+    luaL_register(L, LUA_TABLIBNAME, FFlag::LuwuTableDrop ? tab_funcs_with_drop : tab_funcs);
 
     // Lua 5.1 compat
     lua_pushcfunction(L, tunpack, "unpack");

--- a/VM/src/ltablib.cpp
+++ b/VM/src/ltablib.cpp
@@ -11,6 +11,8 @@
 #include "ldebug.h"
 #include "lvm.h"
 
+LUAU_FASTFLAGVARIABLE(LuwuTableDrop)
+
 static int foreachi(lua_State* L)
 {
     luaL_checktype(L, 1, LUA_TTABLE);
@@ -549,6 +551,51 @@ static int tfind(lua_State* L)
     return 1;
 }
 
+static int tdrop(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+    luaL_checkany(L, 2);
+
+    int n = lua_objlen(L, 1);
+    int maxRemoved = luaL_optinteger(L, 3, INT_MAX);
+    if (maxRemoved <= 0)
+    {
+        lua_pushinteger(L, 0);
+        return 1;
+    }
+
+    LuaTable* t = hvalue(L->base);
+    if (t->readonly)
+        luaG_readonlyerror(L);
+
+    int writeIndex = 1;
+    int removed = 0;
+
+    for (int i = 1; i <= n; ++i)
+    {
+        lua_rawgeti(L, 1, i);
+
+        if (removed < maxRemoved && equalobj(L, L->base + 1, L->top - 1))
+        {
+            lua_pop(L, 1);
+            ++removed;
+            continue;
+        }
+
+        lua_rawseti(L, 1, writeIndex);
+        ++writeIndex;
+    }
+
+    for (int i = writeIndex; i <= n; ++i)
+    {
+        lua_pushnil(L);
+        lua_rawseti(L, 1, i);
+    }
+
+    lua_pushinteger(L, removed);
+    return 1;
+}
+
 static int tclear(lua_State* L)
 {
     luaL_checktype(L, 1, LUA_TTABLE);
@@ -619,6 +666,12 @@ static const luaL_Reg tab_funcs[] = {
 int luaopen_table(lua_State* L)
 {
     luaL_register(L, LUA_TABLIBNAME, tab_funcs);
+
+    if (FFlag::LuwuTableDrop)
+    {
+        lua_pushcfunction(L, tdrop, "drop");
+        lua_setfield(L, -2, "drop");
+    }
 
     // Lua 5.1 compat
     lua_pushcfunction(L, tunpack, "unpack");

--- a/rfcx/table-drop.md
+++ b/rfcx/table-drop.md
@@ -16,17 +16,17 @@ table.remove(t, table.find(t, element))
 ```
 
 However, `table.find` returns `nil` when it cannot find the element specified in the second argument of the function and
-`table.remove` defaults to removing the last element of a table when its second argument is either missing or `nil`. This creates the footgun of unintentionally removing the last element of the table unless you use an `if` statement.
+`table.remove` defaults to removing the last element of a table when its second argument is either missing or `nil`. This creates the footgun of unintentionally removing the last element of the table unless you use an `if` statement or the global `assert` function.
 
 ## Design
 
 First, I am proposing a standard library function for tables to remove elements by value rather than index:
 
-```table.drop(t: {V}, value: V, max: number?)```
+```table.drop(t: {V}, value: V, count: number?)```
 
-`t` refers to the table you're using, `value` is the value you want removed, and `max` is an optional argument specifying the limit of how many occurrences of `value` you want removed.. If `max` is `nil`, every occurrence of `value` is removed from the table. This function does not return anything due to the existence of `table.remove`.
+`t` refers to the table you're using, `value` is the value you want removed, and `count` is an optional argument specifying the limit of how many occurrences of `value` you want removed. If `count` is `nil`, every occurrence of `value` is removed from the table. This function does not return anything due to the existence of `table.remove`.
 
-This function traverses front-to-back (index 1 to `#t`) to find indices where the table element at that index is equal to `value` (using `__eq` semantics), breaking early if `max` is specified and `max` elements have already been found. The indices of elements to remove are pushed in a last-in first-out manner (adding later matches in the table closer to the front of the stack), so that we can directly iterate the stack to remove indices back-to-front so that elements are removed in the correct order. This ensures that we remove the correct indices without worrying about shifting during array removal.
+This function traverses front-to-back (index 1 to `#t`) to find indices where the table element at that index is equal to `value` (using `__eq` semantics), breaking early if `count` is specified and `count` elements have already been found. The indices of elements to remove are pushed in a last-in first-out manner (adding later matches in the table closer to the front of the stack), so that we can directly iterate the stack to remove indices back-to-front so that elements are removed in the correct order. This ensures that we remove the correct indices without worrying about shifting during array removal.
 
 For example:
 ```luau
@@ -43,7 +43,7 @@ Next, I am proposing to add a linter rule warning the user about the `table.remo
 local t = {"apple", "banana", "orange"}
 
 table.remove(t, nil) -- OK
-table.remove(t, table.find("banana")) -- Warning: Using optional variables as the 2nd arg for table.remove is a footgun. Use table.drop instead.
+table.remove(t, table.find(t, "banana")) -- Warning: Using optional variables as the 2nd arg for table.remove is a footgun. Use table.drop instead.
 ```
 
 ## Drawbacks
@@ -56,3 +56,4 @@ While there are no compatibility concerns, this does add a new standard library 
 - Make the linter rule only apply to uses of `table.remove` where function calls that return `number?` are used for the 2nd argument
 - Have `table.drop` return how many times it removed value
 - Renaming `table.drop` (`table.erase`, `table.remval`, etc)
+- Adding optional `start` and `finish` arguments to `table.drop` to specify search distance within the table.

--- a/rfcx/table-drop.md
+++ b/rfcx/table-drop.md
@@ -46,7 +46,7 @@ table.remove(t, table.find(t, "banana")) -- Warning: If this is nil, table.remov
 
 ### Implementation Details
 
-`table.drop` iterates through the indices `1..#t`. The equality check uses the same `__eq` semantics as `table.find`, respecting metamethod. The functions errors on readonly tables like `table.remove`. If `count` is <= 0, it is ignored (treated like `nil`).
+`table.drop` iterates through the indices `1..#t`. The equality check uses the same `__eq` semantics as `table.find`, respecting metamethod. The functions errors on readonly tables like `table.remove`. If `count` is <= 0, the function will error.
 
 The linter rule will warn the user when `table.remove(t, i)` is called and `i` has the `number?` type. Only `i` is underlined. This limits false positives while catching the common footgun `table.remove(t, table.find(t, v))`.
 

--- a/rfcx/table-drop.md
+++ b/rfcx/table-drop.md
@@ -35,20 +35,20 @@ table.insert(t, "banana") -- t is now {"apple", "banana", "banana"}
 table.drop(t, "banana", 1) -- t is now {"apple", "banana"}
 ```
 
-Second, I'm also proposing the following linter rule for the `table.remove(t, foo)` footgun: if `foo` is an expression or function result with `number?` as it's type, the linter warns the user about the footgun by underlining the second argument.
+Second, I'm also proposing the following linter rule for the `table.remove(t, foo)` footgun: if `foo` is an expression or function result with `number?` as it's type, the linter warns the user about the footgun.
 
 ```luau
 local t = {"apple", "banana", "orange"}
 
 table.remove(t, nil) -- OK
-table.remove(t, table.find(t, "banana")) -- Warning: If this is nil, table.remove will remove the last element of the array. This is a common mistake--consider using table.drop instead, or if order is not important, use a key/value table with true values for better performance.
+table.remove(t, table.find(t, "banana")) -- Warning: If this is nil, table.remove will remove the last element of the array. This is a common mistake—consider using table.drop instead, or if order is not important, use a key/value table with true values for better performance.
 ```
 
 ### Implementation Details
 
-`table.drop` should be implemented using a single‑pass compaction over the array part: iterate indices `1..#t`, copy non‑matching elements forward, and nil out trailing slots. This yields O(n) time and O(1) extra space and minimizes repeated equality checks. Use VM equality (the same `__eq` semantics as `table.find`) so metamethods are respected. The implementation must error on readonly tables (same as `table.remove`). `count` is treated as optional; values <= 0 are ignored (treated like `nil`).
+`table.drop` iterates through the indices `1..#t`. The equality check uses the same `__eq` semantics as `table.find`, respecting metamethod. The functions errors on readonly tables like `table.remove`. If `count` is <= 0, it is ignored (treated like `nil`).
 
-Linter rule (scope): warn when `table.remove(t, X)` is called where `X` is a function call or expression whose *static* return type is an optional number (`number?`) and `X` is not the literal `nil`. This limits false positives while catching the common footgun `table.remove(t, table.find(t, v))`.
+The linter rule will warn the user when `table.remove(t, i)` is called and `i` has the `number?` type. Only `i` is underlined. This limits false positives while catching the common footgun `table.remove(t, table.find(t, v))`.
 
 ## Drawbacks
 

--- a/rfcx/table-drop.md
+++ b/rfcx/table-drop.md
@@ -46,7 +46,7 @@ table.remove(t, table.find(t, "banana")) -- Warning: If this is nil, table.remov
 
 ### Implementation Details
 
-`table.drop` iterates through the indices `1..#t`. The equality check uses the same `__eq` semantics as `table.find`, respecting metamethod. The functions errors on readonly tables like `table.remove`. If `count` is <= 0, the function will error.
+`table.drop` iterates through the indices `1..#t`. The equality check uses the same `__eq` semantics as `table.find`, respecting metamethods. The functions errors on readonly tables or if `count` is <= 0.
 
 The linter rule will warn the user when `table.remove(t, i)` is called and `i` has the `number?` type. Only `i` is underlined. This limits false positives while catching the common footgun `table.remove(t, table.find(t, v))`.
 

--- a/rfcx/table-drop.md
+++ b/rfcx/table-drop.md
@@ -35,13 +35,13 @@ table.insert(t, "banana") -- t is now {"apple", "banana", "banana"}
 table.drop(t, "banana", 1) -- t is now {"apple", "banana"}
 ```
 
-Second, I'm also proposing the following linter rule for the `table.remove(t, foo)` footgun: if `foo` is an expression or function result with `number?` as it's type, the linter warns the user about the footgun.
+Second, I'm also proposing the following linter rule for the `table.remove(t, foo)` footgun: if `foo` is an expression or function result with `number?` as it's type, the linter warns the user about the footgun by underlining the second argument.
 
 ```luau
 local t = {"apple", "banana", "orange"}
 
 table.remove(t, nil) -- OK
-table.remove(t, table.find(t, "banana")) -- Warning: Using an optional result as the 2nd argument to `table.remove` may remove the last element by accident; use `table.drop` or check the result instead.
+table.remove(t, table.find(t, "banana")) -- Warning: If this is nil, table.remove will remove the last element of the array. This is a common mistake--consider using table.drop instead, or if order is not important, use a key/value table with true values for better performance.
 ```
 
 ### Implementation Details

--- a/rfcx/table-drop.md
+++ b/rfcx/table-drop.md
@@ -1,0 +1,55 @@
+# `table.drop` & `table.remove` lint improvement
+
+FFlags: LuwuTableDrop, LuwuTableRemoveFootgunLint
+
+## Summary
+
+Add the `table.drop` standard library method for removing table elements by value rather than index, along with a linter improvement
+to prevent the `table.remove` footgun of accidental tail amputation.
+
+## Motivation
+
+To remove table elements by value rather than index, the following pattern is commonly used:
+
+```luau
+table.remove(t, table.find(t, element))
+```
+
+However, `table.find` returns `nil` when it cannot find the element specified in the second argument of the function and
+`table.remove` defaults to removing the last element of a table when its second argument is either missing or `nil`. This creates the footgun of unintentionally removing the last element of the table unless you use an `if` statement.
+
+## Design
+
+First, I am proposing a standard library function for tables to remove elements by value rather than index:
+
+```table.drop(t: {V}, value: V, max: number?)```
+
+`t` refers to the table you're using, `value` is the value you want removed, and `max` is an optional argument specifying the limit of how many occurrences of `value` you want removed.. If `max` is `nil`, every occurrence of `value` is removed from the table. This function does not return anything due to the existence of `table.remove`.
+
+This function traverses front-to-back (index 1 to `#t`) to find indices where the table element at that index is equal to `value` (using `__eq` semantics), breaking early if `max` is specified and `max` elements have already been found. The indices of elements to remove are pushed in a last-in first-out manner (adding later matches in the table closer to the front of the stack), so that we can directly iterate the stack to remove indices back-to-front so that elements are removed in the correct order. This ensures that we remove the correct indices without worrying about shifting during array removal.
+
+For example:
+```luau
+local t = {"apple", "banana", "orange", "orange"}
+
+table.drop(t, "orange") -- t is now {"apple", "banana"}
+table.insert(t, "banana") -- t is now {"apple", "banana", "banana"}
+table.drop(t, "banana", 1) -- t is now {"apple", "banana"}
+```
+
+Next, I am proposing to add a linter rule warning the user about the `table.remove` footgun if their second argument is an optional variable and isn't explicitly `nil`.
+
+```luau
+local t = {"apple", "banana", "orange"}
+
+table.remove(t, nil) -- OK
+table.remove(t, table.find("banana")) -- Warning: Using optional variables as the 2nd arg for table.remove is a footgun. Use table.drop instead.
+```
+
+## Drawbacks
+
+While there are no compatibility concerns, this does add a new standard library function to the language.
+
+## Alternatives
+
+- Simply adding the linter rule would stop the footgun, but it would leave the verbose use of `if` statements as the only solution.

--- a/rfcx/table-drop.md
+++ b/rfcx/table-drop.md
@@ -53,3 +53,6 @@ While there are no compatibility concerns, this does add a new standard library 
 ## Alternatives
 
 - Simply adding the linter rule would stop the footgun, but it would leave the verbose use of `if` statements as the only solution.
+- Make the linter rule only apply to uses of `table.remove` where function calls that return `number?` are used for the 2nd argument
+- Have `table.drop` return how many times it removed value
+- Renaming `table.drop` (`table.erase`, `table.remval`, etc)

--- a/rfcx/table-drop.md
+++ b/rfcx/table-drop.md
@@ -22,11 +22,9 @@ However, `table.find` returns `nil` when it cannot find the element specified in
 
 First, I am proposing a standard library function for tables to remove elements by value rather than index:
 
-```table.drop(t: {V}, value: V, count: number?)```
+```table.drop(t: {V}, value: V, count: number?): number```
 
-`t` refers to the table you're using, `value` is the value you want removed, and `count` is an optional argument specifying the limit of how many occurrences of `value` you want removed. If `count` is `nil`, every occurrence of `value` is removed from the table. This function does not return anything due to the existence of `table.remove`.
-
-This function traverses front-to-back (index 1 to `#t`) to find indices where the table element at that index is equal to `value` (using `__eq` semantics), breaking early if `count` is specified and `count` elements have already been found. The indices of elements to remove are pushed in a last-in first-out manner (adding later matches in the table closer to the front of the stack), so that we can directly iterate the stack to remove indices back-to-front so that elements are removed in the correct order. This ensures that we remove the correct indices without worrying about shifting during array removal.
+`t` refers to the table you're using, `value` is the value you want removed, and `count` is an optional argument specifying the limit of how many occurrences of `value` you want removed. If `count` is `nil`, every occurrence of `value` is removed from the table. The function returns the number of removed elements.
 
 For example:
 ```luau
@@ -37,14 +35,20 @@ table.insert(t, "banana") -- t is now {"apple", "banana", "banana"}
 table.drop(t, "banana", 1) -- t is now {"apple", "banana"}
 ```
 
-Next, I am proposing to add a linter rule warning the user about the `table.remove` footgun if their second argument is an optional variable and isn't explicitly `nil`.
+Second, I'm also proposing the following linter rule for the `table.remove(t, foo)` footgun: if `foo` is an expression or function result with `number?` as it's type, the linter warns the user about the footgun.
 
 ```luau
 local t = {"apple", "banana", "orange"}
 
 table.remove(t, nil) -- OK
-table.remove(t, table.find(t, "banana")) -- Warning: Using optional variables as the 2nd arg for table.remove is a footgun. Use table.drop instead.
+table.remove(t, table.find(t, "banana")) -- Warning: Using an optional result as the 2nd argument to `table.remove` may remove the last element by accident; use `table.drop` or check the result instead.
 ```
+
+### Implementation Details
+
+`table.drop` should be implemented using a single‑pass compaction over the array part: iterate indices `1..#t`, copy non‑matching elements forward, and nil out trailing slots. This yields O(n) time and O(1) extra space and minimizes repeated equality checks. Use VM equality (the same `__eq` semantics as `table.find`) so metamethods are respected. The implementation must error on readonly tables (same as `table.remove`). `count` is treated as optional; values <= 0 are ignored (treated like `nil`).
+
+Linter rule (scope): warn when `table.remove(t, X)` is called where `X` is a function call or expression whose *static* return type is an optional number (`number?`) and `X` is not the literal `nil`. This limits false positives while catching the common footgun `table.remove(t, table.find(t, v))`.
 
 ## Drawbacks
 
@@ -53,7 +57,5 @@ While there are no compatibility concerns, this does add a new standard library 
 ## Alternatives
 
 - Simply adding the linter rule would stop the footgun, but it would leave the verbose use of `if` statements as the only solution.
-- Make the linter rule only apply to uses of `table.remove` where function calls that return `number?` are used for the 2nd argument
-- Have `table.drop` return how many times it removed value
 - Renaming `table.drop` (`table.erase`, `table.remval`, etc)
 - Adding optional `start` and `finish` arguments to `table.drop` to specify search distance within the table.

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -25,6 +25,7 @@ LUAU_FASTFLAG(LuauDeprecatedAttributeOnAnonymousFunctions)
 LUAU_FASTFLAG(LuauAutocompleteSkipErrorTypeInUnion)
 LUAU_FASTFLAG(LuauCheckTypeForDeprecated)
 LUAU_FASTFLAG(LuauDeprecatedAttributeOnAnonymousFunctions)
+LUAU_FASTFLAG(LuwuTableDrop)
 
 using namespace Luau;
 
@@ -363,14 +364,17 @@ TEST_CASE_FIXTURE(ACFixture, "function_parameters")
 
 TEST_CASE_FIXTURE(ACBuiltinsFixture, "get_member_completions")
 {
+    ScopedFastFlag tableDrop{FFlag::LuwuTableDrop, true};
+
     check(R"(
         local a = table.@1
     )");
 
     auto ac = autocomplete('1');
 
-    CHECK_EQ(17, ac.entryMap.size());
+    CHECK_EQ(18, ac.entryMap.size());
     CHECK(ac.entryMap.count("find"));
+    CHECK(ac.entryMap.count("drop"));
     CHECK(ac.entryMap.count("pack"));
     LUAU_CHECK_HAS_NO_KEY(ac.entryMap, "math");
     CHECK_EQ(ac.context, AutocompleteContext::Property);
@@ -469,13 +473,16 @@ TEST_CASE_FIXTURE(ACFixture, "table_intersection")
 
 TEST_CASE_FIXTURE(ACBuiltinsFixture, "get_string_completions")
 {
+    ScopedFastFlag tableDrop{FFlag::LuwuTableDrop, true};
+
     check(R"(
         local a = ("foo"):@1
     )");
 
     auto ac = autocomplete('1');
 
-    CHECK_EQ(17, ac.entryMap.size());
+    CHECK_EQ(18, ac.entryMap.size());
+    CHECK(ac.entryMap.count("drop"));
     CHECK_EQ(ac.context, AutocompleteContext::Property);
 }
 

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -481,8 +481,8 @@ TEST_CASE_FIXTURE(ACBuiltinsFixture, "get_string_completions")
 
     auto ac = autocomplete('1');
 
-    CHECK_EQ(18, ac.entryMap.size());
-    CHECK(ac.entryMap.count("drop"));
+    CHECK_EQ(17, ac.entryMap.size());
+    LUAU_CHECK_HAS_NO_KEY(ac.entryMap, "drop");
     CHECK_EQ(ac.context, AutocompleteContext::Property);
 }
 

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -69,6 +69,7 @@ LUAU_FASTFLAG(DebugLuauUserDefinedClassesRuntime)
 LUAU_FASTFLAG(LuauExportValueSyntax)
 LUAU_FASTFLAG(LuauExportedClassIsNilWorkaround)
 LUAU_FASTFLAG(LuauAutoStack)
+LUAU_FASTFLAG(LuwuTableDrop)
 LUAU_FASTFLAG(LuauUdataMetatablePinned)
 LUAU_FASTFLAG(LuauGcTraceUdata)
 LUAU_DYNAMIC_FASTFLAG(LuauGcTableStepFix)
@@ -1264,6 +1265,8 @@ TEST_CASE("Math")
 
 TEST_CASE("Tables")
 {
+    ScopedFastFlag tableDropFlag{FFlag::LuwuTableDrop, true};
+
     runConformance(
         "tables.luau",
         [](lua_State* L)
@@ -1290,6 +1293,20 @@ TEST_CASE("Tables")
             lua_setglobal(L, "makelud");
         }
     );
+}
+
+TEST_CASE("TableDropFlagDisabled")
+{
+    ScopedFastFlag tableDropFlag{FFlag::LuwuTableDrop, false};
+
+    lua_State* L = luaL_newstate();
+    luaL_openlibs(L);
+
+    lua_getglobal(L, "table");
+    lua_getfield(L, -1, "drop");
+    CHECK(lua_isnil(L, -1));
+
+    lua_close(L);
 }
 
 TEST_CASE("PatternMatch")

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -1967,6 +1967,7 @@ TEST_CASE("Types")
 {
     ScopedFastFlag integerType{FFlag::LuauIntegerType2, true};
     ScopedFastFlag nonePrimitive{FFlag::LuauNonePrimitive, true};
+    ScopedFastFlag tableDropFlag{FFlag::LuwuTableDrop, true};
 
     runConformance(
         "types.luau",

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -10,6 +10,8 @@
 LUAU_FASTFLAG(DebugLuauForceOldSolver)
 LUAU_FASTFLAG(LuauDeprecatedAttributeOnAnonymousFunctions)
 LUAU_FASTFLAG(LuauFunctionUnusedRecursiveLinting)
+LUAU_FASTFLAG(LuwuTableRemoveFootgunLint)
+LUAU_FASTFLAG(LuwuTableDrop)
 
 using namespace Luau;
 
@@ -2307,6 +2309,55 @@ end
     CHECK_EQ(result.warnings[1].text, "Using '#' on a table with string keys is likely a bug");
     CHECK_EQ(result.warnings[2].location.begin.line + 1, 14);
     CHECK_EQ(result.warnings[2].text, "Using 'ipairs' on a table with string keys is likely a bug");
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "TableRemoveFootgunLint")
+{
+    ScopedFastFlag featureFlag{FFlag::LuwuTableRemoveFootgunLint, true};
+
+    LintResult result = lint(R"(
+local t = {"apple", "banana"}
+
+table.remove(t, table.find(t, "banana"))
+table.remove(t, nil)
+
+local i: number? = table.find(t, "apple")
+table.remove(t, i)
+
+local j: number = 1
+table.remove(t, j)
+
+local k = table.find(t, "pear")
+table.remove(t, k)
+)");
+
+    REQUIRE(3 == result.warnings.size());
+    CHECK_EQ(
+        result.warnings[0].text,
+        "Using an optional result as the 2nd argument to `table.remove` may remove the last element when the index is nil; use `table.drop` or check the result instead."
+    );
+    CHECK_EQ(
+        result.warnings[1].text,
+        "Using an optional result as the 2nd argument to `table.remove` may remove the last element when the index is nil; use `table.drop` or check the result instead."
+    );
+    CHECK_EQ(
+        result.warnings[2].text,
+        "Using an optional result as the 2nd argument to `table.remove` may remove the last element when the index is nil; use `table.drop` or check the result instead."
+    );
+}
+
+TEST_CASE_FIXTURE(BuiltinsFixture, "TableRemoveFootgunLintFlagDisabled")
+{
+    ScopedFastFlag featureFlag{FFlag::LuwuTableRemoveFootgunLint, false};
+
+    LintResult result = lint(R"(
+local t = {"apple", "banana"}
+
+local i: number? = table.find(t, "apple")
+table.remove(t, i)
+)");
+
+    REQUIRE(0 == result.warnings.size());
 }
 
 TEST_CASE_FIXTURE(Fixture, "DuplicateConditions")

--- a/tests/Linter.test.cpp
+++ b/tests/Linter.test.cpp
@@ -2316,33 +2316,33 @@ TEST_CASE_FIXTURE(BuiltinsFixture, "TableRemoveFootgunLint")
     ScopedFastFlag featureFlag{FFlag::LuwuTableRemoveFootgunLint, true};
 
     LintResult result = lint(R"(
-local t = {"apple", "banana"}
+        local t = {"apple", "banana"}
 
-table.remove(t, table.find(t, "banana"))
-table.remove(t, nil)
+        table.remove(t, table.find(t, "banana"))
+        table.remove(t, nil)
 
-local i: number? = table.find(t, "apple")
-table.remove(t, i)
+        local i: number? = table.find(t, "apple")
+        table.remove(t, i)
 
-local j: number = 1
-table.remove(t, j)
+        local j: number = 1
+        table.remove(t, j)
 
-local k = table.find(t, "pear")
-table.remove(t, k)
-)");
+        local k = table.find(t, "pear")
+        table.remove(t, k)
+    )");
 
     REQUIRE(3 == result.warnings.size());
     CHECK_EQ(
         result.warnings[0].text,
-        "Using an optional result as the 2nd argument to `table.remove` may remove the last element when the index is nil; use `table.drop` or check the result instead."
+        "If this is `nil`, `table.remove` will remove the last element of the array. This is a common mistake--consider using `table.drop` instead, or if order is not important, use a key/value table with `true` values for better performance."
     );
     CHECK_EQ(
         result.warnings[1].text,
-        "Using an optional result as the 2nd argument to `table.remove` may remove the last element when the index is nil; use `table.drop` or check the result instead."
+        "If this is `nil`, `table.remove` will remove the last element of the array. This is a common mistake--consider using `table.drop` instead, or if order is not important, use a key/value table with `true` values for better performance."
     );
     CHECK_EQ(
         result.warnings[2].text,
-        "Using an optional result as the 2nd argument to `table.remove` may remove the last element when the index is nil; use `table.drop` or check the result instead."
+        "If this is `nil`, `table.remove` will remove the last element of the array. This is a common mistake--consider using `table.drop` instead, or if order is not important, use a key/value table with `true` values for better performance."
     );
 }
 

--- a/tests/conformance/tables.luau
+++ b/tests/conformance/tables.luau
@@ -455,6 +455,24 @@ do
   assert(table.find(t4, makeobjb(500)) == nil)
 end
 
+-- test table.drop
+do
+  local t = {"apple", "banana", "orange", "banana", "pear"}
+  assert(table.drop(t, "banana") == 2)
+  assert(table.concat(t, ",") == "apple,orange,pear")
+
+  local t2 = {"x", "y", "x", "z", "x"}
+  assert(table.drop(t2, "x", 2) == 2)
+  assert(table.concat(t2, ",") == "y,z,x")
+
+  assert(table.drop({1, 2, 1, 3}, 1, 0) == 0)
+  assert(table.drop({1, 2, 3}, 4) == 0)
+  assert(table.drop({1, 2, 3}, 0) == 0)
+
+  local frozen = table.freeze({"a", "b", "a"})
+  assert(pcall(table.drop, frozen, "a") == false)
+end
+
 -- test table.concat
 do
   -- regular usage

--- a/tests/conformance/tables.luau
+++ b/tests/conformance/tables.luau
@@ -465,7 +465,7 @@ do
   assert(table.drop(t2, "x", 2) == 2)
   assert(table.concat(t2, ",") == "y,z,x")
 
-  assert(table.drop({1, 2, 1, 3}, 1, 0) == 0)
+  assert(pcall(table.drop, {1, 2, 1, 3}, 1, 0) == false)
   assert(table.drop({1, 2, 3}, 4) == 0)
   assert(table.drop({1, 2, 3}, 0) == 0)
 


### PR DESCRIPTION
[Rendered](https://github.com/InfraredGodYT/luwu/blob/table-drop/rfcx/table-drop.md)

Add the `table.drop` standard library method for removing table elements by value rather than index, along with a linter improvement to prevent the `table.remove` footgun of accidental tail amputation.