### PR TITLE
Cleanup MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,18 +1,26 @@
 # Maintainer List
 
+RFCs listed are from the [rfcx](./rfcx/) directory.
+
 ## By FFlag
 
-- LuauExternallyManagedBuffers and LuauBufferIsFrozen: @cheesycod
-- LuauDefaultArguments: @Bottersnike
-- LuauGenericNominals, LuauExternTypeGenericMethods, and LuauExternTypeUseDefinitionScope: @deviaze
-- LuauNonePrimitive: @cheesycod
-- LuauExternalString (and DebugLuauAllowNonNullTerminatedStrings for tests): @cheesycod
-- LuauFatCClosure: @cheesycod
-- LuauManagedReferences2: @cheesycod
-- LuauPcallMulti: @cheesycod
-- LuauFunctionUnusedRecursiveLinting, LuauBetterPackAndVariadicMismatchErrors, LuauIndexerModifierMismatchErrors, LuauPropertyModifierMismatchErrors: @MabMabMabMabMab (undercols) authored by @PhoenixWhitefire (merged from upstream)
-- LuauBetterMissingPropertiesTypeError, LuauFunctionUnusedRecursiveLinting: @MabMabMabMabMab and @deviaze (authored by nnullcolumn, who is not an mluau/luwu maintainer; merged from upstream)
+| RFC                                                                             | FFlag                                                                                                                                              | Maintainer   | Note                                        |
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------- |
+| [External Buffers](./rfcx/external-buffers.md)                                  | LuauExternallyManagedBuffers, LuauBufferIsFrozen                                                                                                   | @cheesycod   |                                             |
+| [Function default arguments](./rfcx/function-default-arguments.md)              | LuauDefaultArguments                                                                                                                               | @Bottersnike |                                             |
+| [Generic parameters on extern types](./rfcx/generics-on-extern-types.md)        | LuauGenericNominals, LuauExternTypeGenericMethods, LuauExternTypeUseDefinitionScope                                                                | @deviaze     |                                             |
+| [None Primitive](./rfcx/none.md)                                                | LuauNonePrimitive                                                                                                                                  | @cheesycod   |                                             |
+| [External Strings](./rfcx/external-strings.md)                                  | LuauExternalString, DebugLuauAllowNonNullTerminatedStrings                                                                                         | @cheesycod   | The Debug FFlag is only for the test suite. |
+| ['Fat' C Closures (C Closures with Data)](./rfcx/fat-c-closures.md)             | LuauFatCClosure                                                                                                                                    | @cheesycod   |                                             |
+| [Faster Luwu-managed references](./rfcx/api-luwu-managed-refs.md)               | LuauManagedReferences2                                                                                                                             | @cheesycod   |                                             |
+| [Pcall error handler with multiple return values](./rfcx/api-luaupcallmulti.md) | LuauPcallMulti                                                                                                                                     | @cheesycod   |                                             |
+| N/A                                                                             | LuauFunctionUnusedRecursiveLinting, LuauBetterPackAndVariadicMismatchErrors, LuauIndexerModifierMismatchErrors, LuauPropertyModifierMismatchErrors | N/A          | Merged from upstream.                       |
+| N/A                                                                             | LuauBetterMissingPropertiesTypeError, LuauFunctionUnusedRecursiveLinting                                                                           | @deviaze     | Merged from upstream.                       |
 
-## Other
+Grouped related FFlags together.
 
-- `lua_findunuseduserdatatag`, `lua_findunusedlightuserdatatag`: @PhoenixWhitefire
+## By C API
+
+| RFC                                                                                           | C API                                                     | Maintainer | Note |
+| --------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------- | ---- |
+| [`lua_findunuseduserdatatag`, `lua_findunusedlightuserdatatag`](./rfcx/api-findunusedtags.md) | lua_findunuseduserdatatag, lua_findunusedlightuserdatatag | N/A        |      |


### PR DESCRIPTION
This PR cleans up the `MAINTAINER.md` file into a markdown table for better visibility. Future commits may ignore the pretty formatting if they can't bother the time to fix that.

Also removes former maintainers from the list.

Resolves #39.