### PR TITLE
Move LOAD_BUFFER_DATA to its own IR cmd

### DIFF
--- a/CodeGen/include/Luau/IrData.h
+++ b/CodeGen/include/Luau/IrData.h
@@ -58,6 +58,10 @@ enum class IrCmd : uint8_t
     // A: Rn or Kn
     LOAD_POINTER,
 
+    // Load buffer data (buffer->data) from a Buffer TValue
+    // A: pointer (Buffer from LOAD_POINTER)
+    LOAD_BUFFER_DATA,
+
     // Load a double number from TValue
     // A: Rn or Kn
     LOAD_DOUBLE,

--- a/CodeGen/src/CodeGenUtils.cpp
+++ b/CodeGen/src/CodeGenUtils.cpp
@@ -495,7 +495,7 @@ const Instruction* executeGETTABLEKS(lua_State* L, const Instruction* pc, StkId 
                 if (LUAU_LIKELY(ttisstring(gkey(n)) && tsvalue(gkey(n)) == tsvalue(kv) && !ttisnil(gval(n))))
                 {
                     lua_UserdataDirectFieldGet fn = reinterpret_cast<lua_UserdataDirectFieldGet>(pvalue(gval(n)));
-                    fn(uvalue(rb)->data, resultarg);
+                    fn(L, uvalue(rb)->data, resultarg);
                     return pc;
                 }
 
@@ -505,7 +505,7 @@ const Instruction* executeGETTABLEKS(lua_State* L, const Instruction* pc, StkId 
                     // cache slot for future lookups
                     VM_PATCH_C(pc - 2, gval2slot(dispatch, fptr));
                     lua_UserdataDirectFieldGet fn = reinterpret_cast<lua_UserdataDirectFieldGet>(pvalue(fptr));
-                    fn(uvalue(rb)->data, resultarg);
+                    fn(L, uvalue(rb)->data, resultarg);
                     return pc;
                 }
             }

--- a/CodeGen/src/IrDump.cpp
+++ b/CodeGen/src/IrDump.cpp
@@ -107,6 +107,8 @@ const char* getCmdName(IrCmd cmd)
         return "LOAD_TAG";
     case IrCmd::LOAD_POINTER:
         return "LOAD_POINTER";
+    case IrCmd::LOAD_BUFFER_DATA:
+        return "LOAD_BUFFER_DATA";
     case IrCmd::LOAD_DOUBLE:
         return "LOAD_DOUBLE";
     case IrCmd::LOAD_INT:

--- a/CodeGen/src/IrLoweringA64.cpp
+++ b/CodeGen/src/IrLoweringA64.cpp
@@ -340,6 +340,13 @@ void IrLoweringA64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         build.ldr(inst.regA64, addr);
         break;
     }
+    case IrCmd::LOAD_BUFFER_DATA:
+    {
+        CODEGEN_ASSERT(OP_A(inst).kind == IrOpKind::Inst);
+        inst.regA64 = regs.allocReuse(KindA64::x, index, {OP_A(inst)});
+        build.ldr(inst.regA64, mem(regOp(OP_A(inst)), offsetof(Buffer, data)));
+        break;
+    }
     case IrCmd::LOAD_DOUBLE:
     {
         inst.regA64 = regs.allocReg(KindA64::d, index);
@@ -4236,71 +4243,33 @@ AddressA64 IrLoweringA64::tempAddr(IrOp op, int offset, RegisterA64 tempStorage)
 AddressA64 IrLoweringA64::tempAddrBuffer(IrOp bufferOp, IrOp indexOp, uint8_t tag)
 {
     CODEGEN_ASSERT(tag == LUA_TUSERDATA || tag == LUA_TBUFFER || tag == LUA_TVECTOR);
-    if (tag == LUA_TBUFFER)
+    int dataOffset = tag == LUA_TBUFFER ? 0 : tag == LUA_TVECTOR ? offsetof(LuauVector, v) : offsetof(Udata, data);
+    if (indexOp.kind == IrOpKind::Inst)
     {
-        // data may be inline_data (mode 0) or an non-inline (externally owned) pointer (mode 1/2)
-        //
-        // As such, we have to load the data with a extra ldr instruction
-        RegisterA64 dataPtr = regs.allocTemp(KindA64::x);
-        build.ldr(dataPtr, mem(regOp(bufferOp), offsetof(Buffer, data)));
+        CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd));
 
-        if (indexOp.kind == IrOpKind::Inst)
-        {
-            CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd));
-
-            RegisterA64 temp = regs.allocTemp(KindA64::x);
-            build.add(temp, dataPtr, regOp(indexOp)); // implicit uxtw
-            return mem(temp, 0);
-        }
-        else if (indexOp.kind == IrOpKind::Constant)
-        {
-            // Since the resulting address may be used to load any size, including 1 byte, from an unaligned offset, we are limited by unscaled
-            // encoding
-            if (unsigned(intOp(indexOp)) <= 255)
-                return mem(dataPtr, int(intOp(indexOp)));
-
-            // indexOp can only be negative in dead code (since offsets are checked); this avoids assertion in emitAddOffset
-            if (intOp(indexOp) < 0)
-                return mem(dataPtr, 0);
-
-            RegisterA64 temp = regs.allocTemp(KindA64::x);
-            emitAddOffset(build, temp, dataPtr, size_t(intOp(indexOp)));
-            return mem(temp, 0);
-        }
-
-        CODEGEN_ASSERT(!"Unsupported instruction form");
-        return noreg;
+        RegisterA64 temp = regs.allocTemp(KindA64::x);
+        build.add(temp, regOp(bufferOp), regOp(indexOp)); // implicit uxtw
+        return mem(temp, dataOffset);
     }
-    else // LUA_TUSERDATA or LUA_TVECTOR
+    else if (indexOp.kind == IrOpKind::Constant)
     {
-        int dataOffset = tag == LUA_TVECTOR ? offsetof(LuauVector, v) : offsetof(Udata, data);
-        if (indexOp.kind == IrOpKind::Inst)
-        {
-            CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd));
+        // Since the resulting address may be used to load any size, including 1 byte, from an unaligned offset, we are limited by unscaled
+        // encoding
+        if (unsigned(intOp(indexOp)) + dataOffset <= 255)
+            return mem(regOp(bufferOp), int(intOp(indexOp) + dataOffset));
 
-            RegisterA64 temp = regs.allocTemp(KindA64::x);
-            build.add(temp, regOp(bufferOp), regOp(indexOp)); // implicit uxtw
-            return mem(temp, dataOffset);
-        }
-        else if (indexOp.kind == IrOpKind::Constant)
-        {
-            // Since the resulting address may be used to load any size, including 1 byte, from an unaligned offset, we are limited by unscaled
-            // encoding
-            if (unsigned(intOp(indexOp)) + dataOffset <= 255)
-                return mem(regOp(bufferOp), int(intOp(indexOp) + dataOffset));
+        // indexOp can only be negative in dead code (since offsets are checked); this avoids assertion in emitAddOffset
+        if (intOp(indexOp) < 0)
+            return mem(regOp(bufferOp), dataOffset);
 
-            // indexOp can only be negative in dead code (since offsets are checked); this avoids assertion in emitAddOffset
-            if (intOp(indexOp) < 0)
-                return mem(regOp(bufferOp), dataOffset);
-
-            RegisterA64 temp = regs.allocTemp(KindA64::x);
-            emitAddOffset(build, temp, regOp(bufferOp), size_t(intOp(indexOp)));
-            return mem(temp, dataOffset);
-        }
-
-        CODEGEN_ASSERT(!"Unsupported instruction form");
-        return noreg;
+        RegisterA64 temp = regs.allocTemp(KindA64::x);
+        emitAddOffset(build, temp, regOp(bufferOp), size_t(intOp(indexOp)));
+        return mem(temp, dataOffset);
     }
+
+    CODEGEN_ASSERT(!"Unsupported instruction form");
+    return noreg;
 }
 
 RegisterA64 IrLoweringA64::regOp(IrOp op)

--- a/CodeGen/src/IrLoweringX64.cpp
+++ b/CodeGen/src/IrLoweringX64.cpp
@@ -85,6 +85,13 @@ void IrLoweringX64::lowerInst(IrInst& inst, uint32_t index, const IrBlock& next)
         else
             CODEGEN_ASSERT(!"Unsupported instruction form");
         break;
+    case IrCmd::LOAD_BUFFER_DATA:
+    {
+        CODEGEN_ASSERT(OP_A(inst).kind == IrOpKind::Inst);
+        inst.regX64 = regs.allocRegOrReuse(SizeX64::qword, index, {OP_A(inst)});
+        build.mov(inst.regX64, qword[regOp(OP_A(inst)) + offsetof(Buffer, data)]);
+        break;
+    }
     case IrCmd::LOAD_DOUBLE:
         inst.regX64 = regs.allocReg(SizeX64::xmmword, index);
 
@@ -4119,44 +4126,19 @@ RegisterX64 IrLoweringX64::regOp(IrOp op)
 OperandX64 IrLoweringX64::bufferAddrOp(IrOp bufferOp, IrOp indexOp, uint8_t tag)
 {
     CODEGEN_ASSERT(tag == LUA_TUSERDATA || tag == LUA_TBUFFER || tag == LUA_TVECTOR);
-    if (tag == LUA_TBUFFER)
+    int dataOffset = tag == LUA_TBUFFER ? 0 : tag == LUA_TVECTOR ? offsetof(LuauVector, v) : offsetof(Udata, data);
+    if (indexOp.kind == IrOpKind::Inst)
     {
-        // data may be inline_data (mode 0) or an non-inline (externally owned) pointer (mode 1/2)
-        //
-        // As such, we have to load the data with a extra mov instruction
-        ScopedRegX64 dataPtr{regs, SizeX64::qword};
-        build.mov(dataPtr.reg, qword[regOp(bufferOp) + offsetof(Buffer, data)]);
+        CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd)); // Ensure that high register bits are cleared
+        return regOp(bufferOp) + qwordReg(regOp(indexOp)) + dataOffset;
+    }
+    else if (indexOp.kind == IrOpKind::Constant)
+    {
+        return regOp(bufferOp) + intOp(indexOp) + dataOffset;
+    }
 
-        if (indexOp.kind == IrOpKind::Inst)
-        {
-            CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd));
-            return dataPtr.reg + qwordReg(regOp(indexOp));
-        }
-        else if (indexOp.kind == IrOpKind::Constant)
-        {
-            return dataPtr.reg + intOp(indexOp);
-        }
-
-        CODEGEN_ASSERT(!"Unsupported instruction form");
-        return noreg;
-    } 
-    else 
-    { 
-        // LUA_TUSERDATA or LUA_TVECTOR
-        int dataOffset = tag == LUA_TVECTOR ? offsetof(LuauVector, v) : offsetof(Udata, data);
-        if (indexOp.kind == IrOpKind::Inst)
-        {
-            CODEGEN_ASSERT(!producesDirtyHighRegisterBits(function.instOp(indexOp).cmd)); // Ensure that high register bits are cleared
-            return regOp(bufferOp) + qwordReg(regOp(indexOp)) + dataOffset;
-        }
-        else if (indexOp.kind == IrOpKind::Constant)
-        {
-            return regOp(bufferOp) + intOp(indexOp) + dataOffset;
-        }
-
-        CODEGEN_ASSERT(!"Unsupported instruction form");
-        return noreg;
-    } 
+    CODEGEN_ASSERT(!"Unsupported instruction form");
+    return noreg;
 }
 
 RegisterX64 IrLoweringX64::vecOp(IrOp op, ScopedRegX64& tmp)

--- a/CodeGen/src/IrTranslateBuiltins.cpp
+++ b/CodeGen/src/IrTranslateBuiltins.cpp
@@ -992,7 +992,8 @@ static BuiltinImplResult translateBuiltinBufferRead(
     IrOp buf, intIndex;
     translateBufferArgsAndCheckBounds(build, nparams, arg, args, arg3, size, pcpos, buf, intIndex, false);
 
-    IrOp result = build.inst(readCmd, buf, intIndex, build.constTag(LUA_TBUFFER));
+    IrOp bufData = build.inst(IrCmd::LOAD_BUFFER_DATA, buf);
+    IrOp result = build.inst(readCmd, bufData, intIndex, build.constTag(LUA_TBUFFER));
 
     build.inst(storeCmd, build.vmReg(ra), convCmd == IrCmd::NOP ? result : build.inst(convCmd, result));
     build.inst(IrCmd::STORE_TAG, build.vmReg(ra), build.constTag(storeTag));
@@ -1022,10 +1023,11 @@ static BuiltinImplResult translateBuiltinBufferWrite(
     translateBufferArgsAndCheckBounds(build, nparams, arg, args, arg3, size, pcpos, buf, intIndex, loadInt64);
 
     build.inst(IrCmd::CHECK_BUFFER_MUTABLE, buf, build.vmExit(pcpos));
-
+    
+    IrOp bufData = build.inst(IrCmd::LOAD_BUFFER_DATA, buf);
     IrOp numValue = loadInt64 ? builtinLoadInt64(build, arg3) : builtinLoadDouble(build, arg3);
 
-    build.inst(writeCmd, buf, intIndex, convCmd == IrCmd::NOP ? numValue : build.inst(convCmd, numValue), build.constTag(LUA_TBUFFER));
+    build.inst(writeCmd, bufData, intIndex, convCmd == IrCmd::NOP ? numValue : build.inst(convCmd, numValue), build.constTag(LUA_TBUFFER));
 
     return {BuiltinImplType::Full, 0};
 }

--- a/CodeGen/src/IrUtils.cpp
+++ b/CodeGen/src/IrUtils.cpp
@@ -151,6 +151,8 @@ IrValueKind getCmdValueKind(IrCmd cmd)
         return IrValueKind::Tag;
     case IrCmd::LOAD_POINTER:
         return IrValueKind::Pointer;
+    case IrCmd::LOAD_BUFFER_DATA:
+        return IrValueKind::Pointer;
     case IrCmd::LOAD_DOUBLE:
         return IrValueKind::Double;
     case IrCmd::LOAD_INT:

--- a/CodeGen/src/OptimizeConstProp.cpp
+++ b/CodeGen/src/OptimizeConstProp.cpp
@@ -1608,6 +1608,11 @@ static void constPropInInst(ConstPropState& state, IrBuilder& build, IrFunction&
             state.substituteOrRecordVmRegLoad(inst);
         }
         break;
+    case IrCmd::LOAD_BUFFER_DATA: 
+    {
+        state.substituteOrRecord(inst, index);
+        break;
+    }
     case IrCmd::LOAD_DOUBLE:
     {
         IrOp value = state.tryGetValue(OP_A(inst));

--- a/VM/include/lua.h
+++ b/VM/include/lua.h
@@ -466,7 +466,7 @@ LUA_API int lua_registeruserdatadirectaccess(
 ** field: field name string (will be interned and pinned)
 ** fn:    handler — receives raw userdata data pointer and result TValue slot
 */
-typedef void (*lua_UserdataDirectFieldGet)(void* ud, void* result);
+typedef void (*lua_UserdataDirectFieldGet)(lua_State* L, void* ud, void* result);
 LUA_API void lua_registeruserdatadirectfieldget(lua_State* L, int tag, const char* field, lua_UserdataDirectFieldGet fn);
 
 // Helpers for writing result values from a direct field handler.

--- a/VM/src/lvmexecute.cpp
+++ b/VM/src/lvmexecute.cpp
@@ -580,7 +580,7 @@ reentry:
                             if (LUAU_LIKELY(ttisstring(gkey(n)) && tsvalue(gkey(n)) == tsvalue(kv) && !ttisnil(gval(n))))
                             {
                                 lua_UserdataDirectFieldGet fn = reinterpret_cast<lua_UserdataDirectFieldGet>(pvalue(gval(n)));
-                                fn(uvalue(rb)->data, resultarg);
+                                fn(L, uvalue(rb)->data, resultarg);
                                 VM_NEXT();
                             }
 
@@ -590,7 +590,7 @@ reentry:
                                 // cache slot for future lookups
                                 VM_PATCH_C(pc - 2, gval2slot(dispatch, fptr));
                                 lua_UserdataDirectFieldGet fn = reinterpret_cast<lua_UserdataDirectFieldGet>(pvalue(fptr));
-                                fn(uvalue(rb)->data, resultarg);
+                                fn(L, uvalue(rb)->data, resultarg);
                                 VM_NEXT();
                             }
                         }

--- a/tests/Conformance.test.cpp
+++ b/tests/Conformance.test.cpp
@@ -5058,7 +5058,7 @@ TEST_CASE("lua_findunuseduserdatatag")
     lua_createtable(L, 0, 0);
     lua_setuserdatametatable(L, 0);
     lua_setuserdatadtor(L, 1, [](lua_State*, void*){});
-    lua_registeruserdatadirectfieldget(L, 2, "hina", [](void*, void*){});
+    lua_registeruserdatadirectfieldget(L, 2, "hina", [](lua_State*, void*, void*){});
 
     int available = lua_findunuseduserdatatag(L);
     CHECK_EQ(available, 3);

--- a/tests/DirectFieldAccess.test.cpp
+++ b/tests/DirectFieldAccess.test.cpp
@@ -71,7 +71,7 @@ TEST_CASE("handler_setnumber_result")
         L,
         kTagVec2,
         "X",
-        [](void* ud, void* res)
+        [](lua_State* L, void* ud, void* res)
         {
             lua_userdatadirectfield_setnumber(res, static_cast<Vec2*>(ud)->x);
         }
@@ -101,7 +101,7 @@ TEST_CASE("handler_setboolean_result")
         L,
         kTagVec2,
         "NonZero",
-        [](void* ud, void* r)
+        [](lua_State* L, void* ud, void* r)
         {
             lua_userdatadirectfield_setboolean(r, static_cast<int>(static_cast<Vec2*>(ud)->x != 0 || static_cast<Vec2*>(ud)->y != 0));
         }
@@ -142,7 +142,7 @@ TEST_CASE("repeated_access_handler_called_every_iteration")
         L,
         kTagVec2,
         "X",
-        [](void* ud, void* r)
+        [](lua_State* L, void* ud, void* r)
         {
             handlerHitCount++;
             lua_userdatadirectfield_setnumber(r, static_cast<Vec2*>(ud)->x);
@@ -180,7 +180,7 @@ TEST_CASE("unregistered_tag_falls_through_to_index_metamethod")
         L,
         kTagVec2,
         "X",
-        [](void* ud, void* r)
+        [](lua_State* L, void* ud, void* r)
         {
             handlerHitCount++;
             lua_userdatadirectfield_setnumber(r, static_cast<Vec2*>(ud)->x);
@@ -234,7 +234,7 @@ TEST_CASE("multiple_fields_same_type_dispatch_independently")
         L,
         kTagVec2,
         "X",
-        [](void* ud, void* r)
+        [](lua_State* L, void* ud, void* r)
         {
             lua_userdatadirectfield_setnumber(r, static_cast<Vec2*>(ud)->x);
         }
@@ -243,7 +243,7 @@ TEST_CASE("multiple_fields_same_type_dispatch_independently")
         L,
         kTagVec2,
         "Y",
-        [](void* ud, void* r)
+        [](lua_State* L, void* ud, void* r)
         {
             lua_userdatadirectfield_setnumber(r, static_cast<Vec2*>(ud)->y);
         }
@@ -276,7 +276,7 @@ TEST_CASE("same_field_name_different_tags_dispatch_independently")
         L,
         kTagVec2,
         "X",
-        [](void* ud, void* r)
+        [](lua_State* L, void* ud, void* r)
         {
             lua_userdatadirectfield_setnumber(r, static_cast<Vec2*>(ud)->x);
             handlerHitCount++;
@@ -286,7 +286,7 @@ TEST_CASE("same_field_name_different_tags_dispatch_independently")
         L,
         kTagOther,
         "X",
-        [](void* ud, void* r)
+        [](lua_State* L, void* ud, void* r)
         {
             lua_userdatadirectfield_setnumber(r, 999);
             handlerHitCount++;

--- a/tests/IrLowering.test.cpp
+++ b/tests/IrLowering.test.cpp
@@ -5247,17 +5247,18 @@ bb_bytecode_1:
   %12 = LOAD_DOUBLE R1
   %13 = NUM_TO_INT %12
   CHECK_BUFFER_LEN %11, %13, 0i, 12i, %12, exit(2)
-  %15 = BUFFER_READI32 %11, %13, tbuffer
-  %16 = INT_TO_NUM %15
-  %33 = ADD_INT %13, 4i
-  %35 = BUFFER_READI32 %11, %33, tbuffer
-  %36 = INT_TO_NUM %35
-  %46 = ADD_NUM %16, %36
-  %62 = ADD_INT %13, 8i
-  %64 = BUFFER_READI32 %11, %62, tbuffer
-  %65 = INT_TO_NUM %64
-  %75 = ADD_NUM %46, %65
-  STORE_DOUBLE R2, %75
+  %15 = LOAD_BUFFER_DATA %11
+  %16 = BUFFER_READI32 %15, %13, tbuffer
+  %17 = INT_TO_NUM %16
+  %34 = ADD_INT %13, 4i
+  %37 = BUFFER_READI32 %15, %34, tbuffer
+  %38 = INT_TO_NUM %37
+  %48 = ADD_NUM %17, %38
+  %64 = ADD_INT %13, 8i
+  %67 = BUFFER_READI32 %15, %64, tbuffer
+  %68 = INT_TO_NUM %67
+  %78 = ADD_NUM %48, %68
+  STORE_DOUBLE R2, %78
   STORE_TAG R2, tnumber
   INTERRUPT 23u
   RETURN R2, 1i
@@ -5289,23 +5290,25 @@ bb_bytecode_1:
   %19 = NUM_TO_INT %9
   CHECK_BUFFER_LEN %17, %19, -8i, 4i, %9, bb_exit_6
    ; exit sync: R6, {%9}
-  %21 = BUFFER_READI32 %17, %19, tbuffer
-  %22 = INT_TO_NUM %21
-  %39 = ADD_INT %19, -4i
-  %41 = BUFFER_READI32 %17, %39, tbuffer
-  %42 = INT_TO_NUM %41
-  %52 = ADD_NUM %22, %42
-  %68 = ADD_INT %19, -8i
-  %70 = BUFFER_READI32 %17, %68, tbuffer
-  %71 = INT_TO_NUM %70
-  %81 = ADD_NUM %52, %71
-  STORE_DOUBLE R2, %81
+  %21 = LOAD_BUFFER_DATA %17
+  %22 = BUFFER_READI32 %21, %19, tbuffer
+  %23 = INT_TO_NUM %22
+  %40 = ADD_INT %19, -4i
+  %43 = BUFFER_READI32 %21, %40, tbuffer
+  %44 = INT_TO_NUM %43
+  %54 = ADD_NUM %23, %44
+  %70 = ADD_INT %19, -8i
+  %73 = BUFFER_READI32 %21, %70, tbuffer
+  %74 = INT_TO_NUM %73
+  %84 = ADD_NUM %54, %74
+  STORE_DOUBLE R2, %84
   STORE_TAG R2, tnumber
   INTERRUPT 23u
   RETURN R2, 1i
 )"
     );
 }
+
 TEST_CASE_FIXTURE(LoweringFixture, "BufferRelatedIndicesPositiveDynamicBase")
 {
     CHECK_EQ(
@@ -5330,23 +5333,25 @@ bb_bytecode_1:
   %14 = LOAD_DOUBLE R2
   %15 = NUM_TO_INT %14
   CHECK_BUFFER_LEN %13, %15, 0i, 4i, undef, exit(2)
-  %17 = BUFFER_READI32 %13, %15, tbuffer
-  %18 = INT_TO_NUM %17
-  %33 = LOAD_POINTER R1
-  %35 = NUM_TO_INT %18
-  CHECK_BUFFER_LEN %33, %35, 0i, 12i, %18, bb_exit_7
-   ; exit sync: R8, R3, {%18}
-  %37 = BUFFER_READF32 %33, %35, tbuffer
-  %38 = FLOAT_TO_NUM %37
-  %55 = ADD_INT %35, 4i
-  %57 = BUFFER_READF32 %33, %55, tbuffer
-  %58 = FLOAT_TO_NUM %57
-  %68 = MUL_NUM %38, %58
-  %84 = ADD_INT %35, 8i
-  %86 = BUFFER_READF32 %33, %84, tbuffer
-  %87 = FLOAT_TO_NUM %86
-  %97 = MUL_NUM %68, %87
-  STORE_DOUBLE R4, %97
+  %17 = LOAD_BUFFER_DATA %13
+  %18 = BUFFER_READI32 %17, %15, tbuffer
+  %19 = INT_TO_NUM %18
+  %34 = LOAD_POINTER R1
+  %36 = NUM_TO_INT %19
+  CHECK_BUFFER_LEN %34, %36, 0i, 12i, %19, bb_exit_7
+   ; exit sync: R8, R3, {%19}
+  %38 = LOAD_BUFFER_DATA %34
+  %39 = BUFFER_READF32 %38, %36, tbuffer
+  %40 = FLOAT_TO_NUM %39
+  %57 = ADD_INT %36, 4i
+  %60 = BUFFER_READF32 %38, %57, tbuffer
+  %61 = FLOAT_TO_NUM %60
+  %71 = MUL_NUM %40, %61
+  %87 = ADD_INT %36, 8i
+  %90 = BUFFER_READF32 %38, %87, tbuffer
+  %91 = FLOAT_TO_NUM %90
+  %101 = MUL_NUM %71, %91
+  STORE_DOUBLE R4, %101
   STORE_TAG R4, tnumber
   INTERRUPT 30u
   RETURN R4, 1i
@@ -5413,26 +5418,27 @@ bb_bytecode_2:
   %43 = LOAD_DOUBLE R5
   %44 = NUM_TO_INT %43
   CHECK_BUFFER_LEN %42, %44, 0i, 12i, %43, exit(12)
-  %46 = BUFFER_READF32 %42, %44, tbuffer
-  %47 = FLOAT_TO_NUM %46
-  %64 = ADD_INT %44, 4i
-  %66 = BUFFER_READF32 %42, %64, tbuffer
-  %67 = FLOAT_TO_NUM %66
-  %77 = MUL_NUM %47, %67
-  %93 = ADD_INT %44, 8i
-  %95 = BUFFER_READF32 %42, %93, tbuffer
-  %96 = FLOAT_TO_NUM %95
-  %106 = MUL_NUM %77, %96
+  %46 = LOAD_BUFFER_DATA %42
+  %47 = BUFFER_READF32 %46, %44, tbuffer
+  %48 = FLOAT_TO_NUM %47
+  %65 = ADD_INT %44, 4i
+  %68 = BUFFER_READF32 %46, %65, tbuffer
+  %69 = FLOAT_TO_NUM %68
+  %79 = MUL_NUM %48, %69
+  %95 = ADD_INT %44, 8i
+  %98 = BUFFER_READF32 %46, %95, tbuffer
+  %99 = FLOAT_TO_NUM %98
+  %109 = MUL_NUM %79, %99
   CHECK_TAG R2, tnumber, bb_exit_10
-   ; exit sync: R8, R7, R6, {%96, %77, %106}
-  %113 = LOAD_DOUBLE R2
-  %115 = ADD_NUM %113, %106
-  STORE_DOUBLE R2, %115
+   ; exit sync: R8, R7, R6, {%99, %79, %109}
+  %116 = LOAD_DOUBLE R2
+  %118 = ADD_NUM %116, %109
+  STORE_DOUBLE R2, %118
   CHECK_GC
-  %118 = LOAD_DOUBLE R3
-  %120 = ADD_NUM %43, 12
-  STORE_DOUBLE R5, %120
-  JUMP_CMP_NUM %120, %118, le, bb_bytecode_2, bb_bytecode_3
+  %121 = LOAD_DOUBLE R3
+  %123 = ADD_NUM %43, 12
+  STORE_DOUBLE R5, %123
+  JUMP_CMP_NUM %123, %121, le, bb_bytecode_2, bb_bytecode_3
 bb_bytecode_3:
   INTERRUPT 35u
   RETURN R2, 1i
@@ -5473,25 +5479,26 @@ bb_bytecode_1:
   %21 = NUM_TO_INT %20
   CHECK_BUFFER_LEN %19, %21, 0i, 12i, %20, exit(2)
   CHECK_BUFFER_MUTABLE %19, exit(2)
-  %24 = LOAD_DOUBLE R2
-  %25 = NUM_TO_UINT %24
-  BUFFER_WRITEI32 %19, %21, %25, tbuffer
-  %31 = ADD_NUM %20, 4
-  %42 = ADD_INT %21, 4i
+  %24 = LOAD_BUFFER_DATA %19
+  %25 = LOAD_DOUBLE R2
+  %26 = NUM_TO_UINT %25
+  BUFFER_WRITEI32 %24, %21, %26, tbuffer
+  %32 = ADD_NUM %20, 4
+  %43 = ADD_INT %21, 4i
   CHECK_BUFFER_MUTABLE %19, bb_exit_6
-   ; exit sync: R1, {%31}
-  %45 = LOAD_DOUBLE R3
-  %46 = NUM_TO_UINT %45
-  BUFFER_WRITEI32 %19, %42, %46, tbuffer
-  %52 = ADD_NUM %31, 4
-  %63 = ADD_INT %21, 8i
+   ; exit sync: R1, {%32}
+  %47 = LOAD_DOUBLE R3
+  %48 = NUM_TO_UINT %47
+  BUFFER_WRITEI32 %24, %43, %48, tbuffer
+  %54 = ADD_NUM %32, 4
+  %65 = ADD_INT %21, 8i
   CHECK_BUFFER_MUTABLE %19, bb_exit_7
-   ; exit sync: R1, {%52}
-  %66 = LOAD_DOUBLE R4
-  %67 = NUM_TO_UINT %66
-  BUFFER_WRITEI32 %19, %63, %67, tbuffer
-  %73 = ADD_NUM %52, 4
-  STORE_DOUBLE R1, %73
+   ; exit sync: R1, {%54}
+  %69 = LOAD_DOUBLE R4
+  %70 = NUM_TO_UINT %69
+  BUFFER_WRITEI32 %24, %65, %70, tbuffer
+  %76 = ADD_NUM %54, 4
+  STORE_DOUBLE R1, %76
   INTERRUPT 27u
   RETURN R1, 1i
 )"
@@ -5522,17 +5529,18 @@ bb_bytecode_1:
   %19 = NUM_TO_INT %9
   CHECK_BUFFER_LEN %17, %19, 0i, 12i, %9, bb_exit_6
    ; exit sync: R6, {%9}
-  %21 = BUFFER_READI32 %17, %19, tbuffer
-  %22 = INT_TO_NUM %21
-  %39 = ADD_INT %19, 4i
-  %41 = BUFFER_READI32 %17, %39, tbuffer
-  %42 = INT_TO_NUM %41
-  %52 = ADD_NUM %22, %42
-  %68 = ADD_INT %19, 8i
-  %70 = BUFFER_READI32 %17, %68, tbuffer
-  %71 = INT_TO_NUM %70
-  %81 = ADD_NUM %52, %71
-  STORE_DOUBLE R2, %81
+  %21 = LOAD_BUFFER_DATA %17
+  %22 = BUFFER_READI32 %21, %19, tbuffer
+  %23 = INT_TO_NUM %22
+  %40 = ADD_INT %19, 4i
+  %43 = BUFFER_READI32 %21, %40, tbuffer
+  %44 = INT_TO_NUM %43
+  %54 = ADD_NUM %23, %44
+  %70 = ADD_INT %19, 8i
+  %73 = BUFFER_READI32 %21, %70, tbuffer
+  %74 = INT_TO_NUM %73
+  %84 = ADD_NUM %54, %74
+  STORE_DOUBLE R2, %84
   STORE_TAG R2, tnumber
   INTERRUPT 23u
   RETURN R2, 1i
@@ -5562,17 +5570,18 @@ bb_bytecode_1:
   %12 = LOAD_DOUBLE R1
   %13 = NUM_TO_INT %12
   CHECK_BUFFER_LEN %11, %13, -4i, 8i, %12, exit(2)
-  %15 = BUFFER_READI32 %11, %13, tbuffer
-  %16 = INT_TO_NUM %15
-  %33 = ADD_INT %13, -4i
-  %35 = BUFFER_READI32 %11, %33, tbuffer
-  %36 = INT_TO_NUM %35
-  %46 = ADD_NUM %16, %36
-  %62 = ADD_INT %13, 4i
-  %64 = BUFFER_READI32 %11, %62, tbuffer
-  %65 = INT_TO_NUM %64
-  %75 = ADD_NUM %46, %65
-  STORE_DOUBLE R2, %75
+  %15 = LOAD_BUFFER_DATA %11
+  %16 = BUFFER_READI32 %15, %13, tbuffer
+  %17 = INT_TO_NUM %16
+  %34 = ADD_INT %13, -4i
+  %37 = BUFFER_READI32 %15, %34, tbuffer
+  %38 = INT_TO_NUM %37
+  %48 = ADD_NUM %17, %38
+  %64 = ADD_INT %13, 4i
+  %67 = BUFFER_READI32 %15, %64, tbuffer
+  %68 = INT_TO_NUM %67
+  %78 = ADD_NUM %48, %68
+  STORE_DOUBLE R2, %78
   STORE_TAG R2, tnumber
   INTERRUPT 23u
   RETURN R2, 1i
@@ -5619,41 +5628,43 @@ bb_bytecode_1:
   %27 = NUM_TO_INT %10
   CHECK_BUFFER_LEN %25, %27, 0i, 1i, undef, bb_exit_19
    ; exit sync: R8, R5, {%10}
-  %29 = BUFFER_READI8 %25, %27, tbuffer
+  %29 = LOAD_BUFFER_DATA %25
+  %30 = BUFFER_READI8 %29, %27, tbuffer
   CHECK_BUFFER_MUTABLE %25, bb_exit_20
-   ; exit sync: R6, R5, {%29, %10}
-  BUFFER_WRITEI8 %25, %27, %29, tbuffer
-  %71 = BUFFER_READU8 %25, %27, tbuffer
+   ; exit sync: R6, R5, {%30, %10}
+  BUFFER_WRITEI8 %29, %27, %30, tbuffer
+  %74 = BUFFER_READU8 %29, %27, tbuffer
   CHECK_BUFFER_MUTABLE %25, bb_exit_21
-   ; exit sync: R6, {%71}
-  BUFFER_WRITEI8 %25, %27, %71, tbuffer
-  %109 = LOAD_POINTER R2
-  CHECK_BUFFER_LEN %109, %27, 0i, 2i, %10, exit(32)
-  %113 = BUFFER_READI8 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_22
-   ; exit sync: R6, {%113}
-  BUFFER_WRITEI8 %109, %27, %113, tbuffer
-  %155 = BUFFER_READU8 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_23
-   ; exit sync: R6, {%155}
-  BUFFER_WRITEI8 %109, %27, %155, tbuffer
-  %195 = ADD_INT %27, 1i
-  %197 = BUFFER_READI8 %109, %195, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_24
-   ; exit sync: R6, R5, {%197, %10}
-  BUFFER_WRITEI8 %109, %195, %197, tbuffer
-  %239 = BUFFER_READU8 %109, %195, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_25
-   ; exit sync: R6, {%239}
-  BUFFER_WRITEI8 %109, %195, %239, tbuffer
-  %281 = BUFFER_READI16 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_26
-   ; exit sync: R6, R5, {%281, %10}
-  BUFFER_WRITEI16 %109, %27, %281, tbuffer
-  %323 = BUFFER_READU16 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_27
-   ; exit sync: R6, {%323}
-  BUFFER_WRITEI16 %109, %27, %323, tbuffer
+   ; exit sync: R6, {%74}
+  BUFFER_WRITEI8 %29, %27, %74, tbuffer
+  %113 = LOAD_POINTER R2
+  CHECK_BUFFER_LEN %113, %27, 0i, 2i, %10, exit(32)
+  %117 = LOAD_BUFFER_DATA %113
+  %118 = BUFFER_READI8 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_22
+   ; exit sync: R6, {%118}
+  BUFFER_WRITEI8 %117, %27, %118, tbuffer
+  %162 = BUFFER_READU8 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_23
+   ; exit sync: R6, {%162}
+  BUFFER_WRITEI8 %117, %27, %162, tbuffer
+  %203 = ADD_INT %27, 1i
+  %206 = BUFFER_READI8 %117, %203, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_24
+   ; exit sync: R6, R5, {%206, %10}
+  BUFFER_WRITEI8 %117, %203, %206, tbuffer
+  %250 = BUFFER_READU8 %117, %203, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_25
+   ; exit sync: R6, {%250}
+  BUFFER_WRITEI8 %117, %203, %250, tbuffer
+  %294 = BUFFER_READI16 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_26
+   ; exit sync: R6, R5, {%294, %10}
+  BUFFER_WRITEI16 %117, %27, %294, tbuffer
+  %338 = BUFFER_READU16 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_27
+   ; exit sync: R6, {%338}
+  BUFFER_WRITEI16 %117, %27, %338, tbuffer
   INTERRUPT 112u
   RETURN R0, 0i
 )"
@@ -5680,41 +5691,43 @@ bb_bytecode_1:
   %27 = NUM_TO_INT %10
   CHECK_BUFFER_LEN %25, %27, 0i, 1i, undef, bb_exit_19
    ; exit sync: R8, R5, {%11}
-  %29 = BUFFER_READI8 %25, %27, tbuffer
+  %29 = LOAD_BUFFER_DATA %25
+  %30 = BUFFER_READI8 %29, %27, tbuffer
   CHECK_BUFFER_MUTABLE %25, bb_exit_20
-   ; exit sync: R6, R5, {%11, %29}
-  BUFFER_WRITEI8 %25, %27, %29, tbuffer
-  %71 = BUFFER_READU8 %25, %27, tbuffer
+   ; exit sync: R6, R5, {%11, %30}
+  BUFFER_WRITEI8 %29, %27, %30, tbuffer
+  %74 = BUFFER_READU8 %29, %27, tbuffer
   CHECK_BUFFER_MUTABLE %25, bb_exit_21
-   ; exit sync: R6, {%71}
-  BUFFER_WRITEI8 %25, %27, %71, tbuffer
-  %109 = LOAD_POINTER R2
-  CHECK_BUFFER_LEN %109, %27, 0i, 2i, %10, exit(32)
-  %113 = BUFFER_READI8 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_22
-   ; exit sync: R6, {%113}
-  BUFFER_WRITEI8 %109, %27, %113, tbuffer
-  %155 = BUFFER_READU8 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_23
-   ; exit sync: R6, {%155}
-  BUFFER_WRITEI8 %109, %27, %155, tbuffer
-  %195 = ADD_INT %27, 1i
-  %197 = BUFFER_READI8 %109, %195, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_24
-   ; exit sync: R6, R5, {%197, %10}
-  BUFFER_WRITEI8 %109, %195, %197, tbuffer
-  %239 = BUFFER_READU8 %109, %195, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_25
-   ; exit sync: R6, {%239}
-  BUFFER_WRITEI8 %109, %195, %239, tbuffer
-  %281 = BUFFER_READI16 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_26
-   ; exit sync: R6, R5, {%11, %281}
-  BUFFER_WRITEI16 %109, %27, %281, tbuffer
-  %323 = BUFFER_READU16 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_27
-   ; exit sync: R6, {%323}
-  BUFFER_WRITEI16 %109, %27, %323, tbuffer
+   ; exit sync: R6, {%74}
+  BUFFER_WRITEI8 %29, %27, %74, tbuffer
+  %113 = LOAD_POINTER R2
+  CHECK_BUFFER_LEN %113, %27, 0i, 2i, %10, exit(32)
+  %117 = LOAD_BUFFER_DATA %113
+  %118 = BUFFER_READI8 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_22
+   ; exit sync: R6, {%118}
+  BUFFER_WRITEI8 %117, %27, %118, tbuffer
+  %162 = BUFFER_READU8 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_23
+   ; exit sync: R6, {%162}
+  BUFFER_WRITEI8 %117, %27, %162, tbuffer
+  %203 = ADD_INT %27, 1i
+  %206 = BUFFER_READI8 %117, %203, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_24
+   ; exit sync: R6, R5, {%206, %10}
+  BUFFER_WRITEI8 %117, %203, %206, tbuffer
+  %250 = BUFFER_READU8 %117, %203, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_25
+   ; exit sync: R6, {%250}
+  BUFFER_WRITEI8 %117, %203, %250, tbuffer
+  %294 = BUFFER_READI16 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_26
+   ; exit sync: R6, R5, {%11, %294}
+  BUFFER_WRITEI16 %117, %27, %294, tbuffer
+  %338 = BUFFER_READU16 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_27
+   ; exit sync: R6, {%338}
+  BUFFER_WRITEI16 %117, %27, %338, tbuffer
   INTERRUPT 112u
   RETURN R0, 0i
 )"
@@ -5755,41 +5768,43 @@ bb_bytecode_1:
   %27 = NUM_TO_INT %11
   CHECK_BUFFER_LEN %25, %27, 0i, 1i, undef, bb_exit_19
    ; exit sync: R8, R5, {%11}
-  %29 = BUFFER_READI8 %25, %27, tbuffer
+  %29 = LOAD_BUFFER_DATA %25
+  %30 = BUFFER_READI8 %29, %27, tbuffer
   CHECK_BUFFER_MUTABLE %25, bb_exit_20
-   ; exit sync: R6, R5, {%11, %29}
-  BUFFER_WRITEI8 %25, %27, %29, tbuffer
-  %71 = BUFFER_READU8 %25, %27, tbuffer
+   ; exit sync: R6, R5, {%11, %30}
+  BUFFER_WRITEI8 %29, %27, %30, tbuffer
+  %74 = BUFFER_READU8 %29, %27, tbuffer
   CHECK_BUFFER_MUTABLE %25, bb_exit_21
-   ; exit sync: R6, {%71}
-  BUFFER_WRITEI8 %25, %27, %71, tbuffer
-  %109 = LOAD_POINTER R2
-  CHECK_BUFFER_LEN %109, %27, 0i, 2i, %11, exit(32)
-  %113 = BUFFER_READI8 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_22
-   ; exit sync: R6, {%113}
-  BUFFER_WRITEI8 %109, %27, %113, tbuffer
-  %155 = BUFFER_READU8 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_23
-   ; exit sync: R6, {%155}
-  BUFFER_WRITEI8 %109, %27, %155, tbuffer
-  %195 = ADD_INT %27, 1i
-  %197 = BUFFER_READI8 %109, %195, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_24
-   ; exit sync: R6, R5, {%10, %197}
-  BUFFER_WRITEI8 %109, %195, %197, tbuffer
-  %239 = BUFFER_READU8 %109, %195, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_25
-   ; exit sync: R6, {%239}
-  BUFFER_WRITEI8 %109, %195, %239, tbuffer
-  %281 = BUFFER_READI16 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_26
-   ; exit sync: R6, R5, {%11, %281}
-  BUFFER_WRITEI16 %109, %27, %281, tbuffer
-  %323 = BUFFER_READU16 %109, %27, tbuffer
-  CHECK_BUFFER_MUTABLE %109, bb_exit_27
-   ; exit sync: R6, {%323}
-  BUFFER_WRITEI16 %109, %27, %323, tbuffer
+   ; exit sync: R6, {%74}
+  BUFFER_WRITEI8 %29, %27, %74, tbuffer
+  %113 = LOAD_POINTER R2
+  CHECK_BUFFER_LEN %113, %27, 0i, 2i, %11, exit(32)
+  %117 = LOAD_BUFFER_DATA %113
+  %118 = BUFFER_READI8 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_22
+   ; exit sync: R6, {%118}
+  BUFFER_WRITEI8 %117, %27, %118, tbuffer
+  %162 = BUFFER_READU8 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_23
+   ; exit sync: R6, {%162}
+  BUFFER_WRITEI8 %117, %27, %162, tbuffer
+  %203 = ADD_INT %27, 1i
+  %206 = BUFFER_READI8 %117, %203, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_24
+   ; exit sync: R6, R5, {%10, %206}
+  BUFFER_WRITEI8 %117, %203, %206, tbuffer
+  %250 = BUFFER_READU8 %117, %203, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_25
+   ; exit sync: R6, {%250}
+  BUFFER_WRITEI8 %117, %203, %250, tbuffer
+  %294 = BUFFER_READI16 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_26
+   ; exit sync: R6, R5, {%11, %294}
+  BUFFER_WRITEI16 %117, %27, %294, tbuffer
+  %338 = BUFFER_READU16 %117, %27, tbuffer
+  CHECK_BUFFER_MUTABLE %113, bb_exit_27
+   ; exit sync: R6, {%338}
+  BUFFER_WRITEI16 %117, %27, %338, tbuffer
   INTERRUPT 112u
   RETURN R0, 0i
 )"
@@ -5822,13 +5837,14 @@ bb_bytecode_1:
   %23 = LOAD_POINTER R0
   CHECK_BUFFER_LEN %23, %13, 0i, 8i, %11, bb_exit_6
    ; exit sync: R2, {%11, %13}
-  %27 = BUFFER_READI32 %23, %13, tbuffer
-  %28 = INT_TO_NUM %27
-  %45 = ADD_INT %13, 4i
-  %47 = BUFFER_READI32 %23, %45, tbuffer
-  %48 = INT_TO_NUM %47
-  %58 = ADD_NUM %28, %48
-  STORE_SPLIT_TVALUE R2, tnumber, %58
+  %27 = LOAD_BUFFER_DATA %23
+  %28 = BUFFER_READI32 %27, %13, tbuffer
+  %29 = INT_TO_NUM %28
+  %46 = ADD_INT %13, 4i
+  %49 = BUFFER_READI32 %27, %46, tbuffer
+  %50 = INT_TO_NUM %49
+  %60 = ADD_NUM %29, %50
+  STORE_SPLIT_TVALUE R2, tnumber, %60
   INTERRUPT 22u
   RETURN R2, 1i
 )"
@@ -5859,17 +5875,18 @@ bb_bytecode_1:
   %19 = NUM_TO_INT %9
   CHECK_BUFFER_LEN %17, %19, 0i, 12i, %9, bb_exit_6
    ; exit sync: R6, {%9}
-  %21 = BUFFER_READI32 %17, %19, tbuffer
-  %22 = INT_TO_NUM %21
-  %45 = ADD_INT %19, 4i
-  %47 = BUFFER_READI32 %17, %45, tbuffer
-  %48 = INT_TO_NUM %47
-  %58 = ADD_NUM %22, %48
-  %80 = ADD_INT %19, 8i
-  %82 = BUFFER_READI32 %17, %80, tbuffer
-  %83 = INT_TO_NUM %82
-  %93 = ADD_NUM %58, %83
-  STORE_DOUBLE R2, %93
+  %21 = LOAD_BUFFER_DATA %17
+  %22 = BUFFER_READI32 %21, %19, tbuffer
+  %23 = INT_TO_NUM %22
+  %46 = ADD_INT %19, 4i
+  %49 = BUFFER_READI32 %21, %46, tbuffer
+  %50 = INT_TO_NUM %49
+  %60 = ADD_NUM %23, %50
+  %82 = ADD_INT %19, 8i
+  %85 = BUFFER_READI32 %21, %82, tbuffer
+  %86 = INT_TO_NUM %85
+  %96 = ADD_NUM %60, %86
+  STORE_DOUBLE R2, %96
   STORE_TAG R2, tnumber
   INTERRUPT 25u
   RETURN R2, 1i
@@ -5902,17 +5919,18 @@ bb_bytecode_1:
   %19 = NUM_TO_INT %9
   CHECK_BUFFER_LEN %17, %19, 0i, 4i, undef, bb_exit_5
    ; exit sync: R5, {%9}
-  %21 = BUFFER_READI32 %17, %19, tbuffer
-  %22 = INT_TO_NUM %21
-  %29 = ADD_NUM %8, 1
-  %35 = MUL_NUM %29, 8
-  %45 = NUM_TO_INT %35
-  CHECK_BUFFER_LEN %17, %45, 0i, 4i, undef, bb_exit_6
-   ; exit sync: R7, R6, R3, {%29, %35, %22}
-  %47 = BUFFER_READI32 %17, %45, tbuffer
-  %48 = INT_TO_NUM %47
-  %58 = ADD_NUM %22, %48
-  STORE_DOUBLE R2, %58
+  %21 = LOAD_BUFFER_DATA %17
+  %22 = BUFFER_READI32 %21, %19, tbuffer
+  %23 = INT_TO_NUM %22
+  %30 = ADD_NUM %8, 1
+  %36 = MUL_NUM %30, 8
+  %46 = NUM_TO_INT %36
+  CHECK_BUFFER_LEN %17, %46, 0i, 4i, undef, bb_exit_6
+   ; exit sync: R7, R6, R3, {%30, %36, %23}
+  %49 = BUFFER_READI32 %21, %46, tbuffer
+  %50 = INT_TO_NUM %49
+  %60 = ADD_NUM %23, %50
+  STORE_DOUBLE R2, %60
   STORE_TAG R2, tnumber
   INTERRUPT 16u
   RETURN R2, 1i
@@ -5950,12 +5968,13 @@ bb_bytecode_1:
   %58 = TRUNCATE_UINT %10
   CHECK_BUFFER_LEN %56, %58, 0i, 24i, undef, bb_exit_9
    ; exit sync: R4, R3, R2, {%44, %27, %10}
-  %60 = BUFFER_READF64 %56, %58, tbuffer
-  %73 = BUFFER_READF64 %56, %27, tbuffer
-  %83 = ADD_NUM %60, %73
-  %95 = BUFFER_READF64 %56, %44, tbuffer
-  %105 = ADD_NUM %83, %95
-  STORE_SPLIT_TVALUE R5, tnumber, %105
+  %60 = LOAD_BUFFER_DATA %56
+  %61 = BUFFER_READF64 %60, %58, tbuffer
+  %75 = BUFFER_READF64 %60, %27, tbuffer
+  %85 = ADD_NUM %61, %75
+  %98 = BUFFER_READF64 %60, %44, tbuffer
+  %108 = ADD_NUM %85, %98
+  STORE_SPLIT_TVALUE R5, tnumber, %108
   INTERRUPT 44u
   RETURN R5, 1i
 )"
@@ -5984,16 +6003,17 @@ bb_bytecode_1:
   %12 = LOAD_DOUBLE R1
   %13 = NUM_TO_INT %12
   CHECK_BUFFER_LEN %11, %13, -1i, 7i, %12, exit(2)
-  %15 = BUFFER_READI8 %11, %13, tbuffer
-  %16 = INT_TO_NUM %15
-  %33 = ADD_INT %13, 4i
-  %35 = BUFFER_READI8 %11, %33, tbuffer
-  %36 = INT_TO_NUM %35
-  %46 = ADD_NUM %16, %36
-  %62 = ADD_INT %13, -1i
-  %64 = BUFFER_READF64 %11, %62, tbuffer
-  %74 = ADD_NUM %46, %64
-  STORE_DOUBLE R2, %74
+  %15 = LOAD_BUFFER_DATA %11
+  %16 = BUFFER_READI8 %15, %13, tbuffer
+  %17 = INT_TO_NUM %16
+  %34 = ADD_INT %13, 4i
+  %37 = BUFFER_READI8 %15, %34, tbuffer
+  %38 = INT_TO_NUM %37
+  %48 = ADD_NUM %17, %38
+  %64 = ADD_INT %13, -1i
+  %67 = BUFFER_READF64 %15, %64, tbuffer
+  %77 = ADD_NUM %48, %67
+  STORE_DOUBLE R2, %77
   STORE_TAG R2, tnumber
   INTERRUPT 23u
   RETURN R2, 1i
@@ -6029,17 +6049,18 @@ bb_bytecode_1:
   %26 = NUM_TO_INT %16
   CHECK_BUFFER_LEN %24, %26, 0i, 1i, undef, bb_exit_5
    ; exit sync: R6, {%16}
-  %28 = BUFFER_READU8 %24, %26, tbuffer
-  %29 = INT_TO_NUM %28
-  STORE_DOUBLE R4, %29
+  %28 = LOAD_BUFFER_DATA %24
+  %29 = BUFFER_READU8 %28, %26, tbuffer
+  %30 = INT_TO_NUM %29
+  STORE_DOUBLE R4, %30
   STORE_TAG R4, tnumber
-  %48 = ADD_NUM %16, R3
-  %58 = NUM_TO_INT %48
-  CHECK_BUFFER_LEN %24, %58, 0i, 1i, undef, bb_exit_6
-   ; exit sync: R8, R7, {%16, %48}
-  %60 = BUFFER_READU8 %24, %58, tbuffer
-  %61 = INT_TO_NUM %60
-  STORE_DOUBLE R5, %61
+  %49 = ADD_NUM %16, R3
+  %59 = NUM_TO_INT %49
+  CHECK_BUFFER_LEN %24, %59, 0i, 1i, undef, bb_exit_6
+   ; exit sync: R8, R7, {%16, %49}
+  %62 = BUFFER_READU8 %28, %59, tbuffer
+  %63 = INT_TO_NUM %62
+  STORE_DOUBLE R5, %63
   STORE_TAG R5, tnumber
   INTERRUPT 15u
   RETURN R4, 2i
@@ -6083,16 +6104,17 @@ bb_bytecode_1:
   %28 = NUM_TO_INT %27
   CHECK_BUFFER_LEN %26, %28, 0i, 4i, undef, bb_exit_5
    ; exit sync: R5, {%16, %17}
-  %30 = BUFFER_READI32 %26, %28, tbuffer
-  %31 = INT_TO_NUM %30
-  %41 = LOAD_DOUBLE R4
-  %42 = NUM_TO_INT %41
-  CHECK_BUFFER_LEN %26, %42, 0i, 4i, undef, bb_exit_6
-   ; exit sync: R6, R5, {%31, %16, %17}
-  %44 = BUFFER_READI32 %26, %42, tbuffer
-  %45 = INT_TO_NUM %44
-  %55 = ADD_NUM %31, %45
-  STORE_SPLIT_TVALUE R5, tnumber, %55
+  %30 = LOAD_BUFFER_DATA %26
+  %31 = BUFFER_READI32 %30, %28, tbuffer
+  %32 = INT_TO_NUM %31
+  %42 = LOAD_DOUBLE R4
+  %43 = NUM_TO_INT %42
+  CHECK_BUFFER_LEN %26, %43, 0i, 4i, undef, bb_exit_6
+   ; exit sync: R6, R5, {%32, %16, %17}
+  %46 = BUFFER_READI32 %30, %43, tbuffer
+  %47 = INT_TO_NUM %46
+  %57 = ADD_NUM %32, %47
+  STORE_SPLIT_TVALUE R5, tnumber, %57
   INTERRUPT 16u
   RETURN R5, 1i
 )"
@@ -6131,12 +6153,13 @@ bb_bytecode_1:
    ; exit sync: R4, R3, {}
   CHECK_BUFFER_MUTABLE %15, bb_exit_13
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEF64 %15, 0i, 3.1400000000000001, tbuffer
+  %20 = LOAD_BUFFER_DATA %15
+  BUFFER_WRITEF64 %20, 0i, 3.1400000000000001, tbuffer
   STORE_SPLIT_TVALUE R3, tnumber, 4
   STORE_SPLIT_TVALUE R4, tnumber, 170
   SET_SAVEDPC 12u
-  %29 = INVOKE_FASTCALL 67u, R1, R0, R3, R4, 3i, 1i
-  CHECK_FASTCALL_RES %29, bb_fallback_4
+  %30 = INVOKE_FASTCALL 67u, R1, R0, R3, R4, 3i, 1i
+  CHECK_FASTCALL_RES %30, bb_fallback_4
   JUMP bb_linear_11
 bb_linear_11:
   STORE_DOUBLE R4, 5
@@ -6144,25 +6167,25 @@ bb_linear_11:
   STORE_DOUBLE R5, 187
   STORE_TAG R5, tnumber
   SET_SAVEDPC 20u
-  %98 = INVOKE_FASTCALL 67u, R2, R0, R4, R5, 3i, 1i
-  CHECK_FASTCALL_RES %98, bb_fallback_6
+  %100 = INVOKE_FASTCALL 67u, R2, R0, R4, R5, 3i, 1i
+  CHECK_FASTCALL_RES %100, bb_fallback_6
   STORE_DOUBLE R5, 0
   STORE_TAG R5, tnumber
   STORE_DOUBLE R6, 255
   STORE_TAG R6, tnumber
   SET_SAVEDPC 28u
-  %107 = INVOKE_FASTCALL 67u, R3, R0, R5, R6, 3i, 1i
-  CHECK_FASTCALL_RES %107, bb_fallback_8
+  %109 = INVOKE_FASTCALL 67u, R3, R0, R5, R6, 3i, 1i
+  CHECK_FASTCALL_RES %109, bb_fallback_8
   CHECK_BUFFER_LEN %15, 0i, 0i, 8i, undef, exit(34)
-  %113 = BUFFER_READF64 %15, 0i, tbuffer
-  STORE_DOUBLE R4, %113
+  %116 = BUFFER_READF64 %20, 0i, tbuffer
+  STORE_DOUBLE R4, %116
   STORE_TAG R4, tnumber
-  %116 = LOAD_TVALUE R1
-  STORE_TVALUE R5, %116
-  %118 = LOAD_TVALUE R2
-  STORE_TVALUE R6, %118
-  %120 = LOAD_TVALUE R3
-  STORE_TVALUE R7, %120
+  %119 = LOAD_TVALUE R1
+  STORE_TVALUE R5, %119
+  %121 = LOAD_TVALUE R2
+  STORE_TVALUE R6, %121
+  %123 = LOAD_TVALUE R3
+  STORE_TVALUE R7, %123
   INTERRUPT 42u
   RETURN R4, 4i
 )"
@@ -7401,14 +7424,15 @@ bb_bytecode_1:
   implicit CHECK_SAFE_ENV exit(0)
   %7 = LOAD_POINTER R0
   CHECK_BUFFER_LEN %7, 0i, 0i, 8i, undef, exit(2)
-  %10 = BUFFER_READF32 %7, 0i, tbuffer
-  %11 = FLOAT_TO_NUM %10
-  %32 = MUL_NUM %11, %11
-  %41 = BUFFER_READF32 %7, 4i, tbuffer
-  %42 = FLOAT_TO_NUM %41
-  %63 = MUL_NUM %42, %42
-  %72 = ADD_NUM %32, %63
-  STORE_DOUBLE R1, %72
+  %10 = LOAD_BUFFER_DATA %7
+  %11 = BUFFER_READF32 %10, 0i, tbuffer
+  %12 = FLOAT_TO_NUM %11
+  %34 = MUL_NUM %12, %12
+  %44 = BUFFER_READF32 %10, 4i, tbuffer
+  %45 = FLOAT_TO_NUM %44
+  %67 = MUL_NUM %45, %45
+  %76 = ADD_NUM %34, %67
+  STORE_DOUBLE R1, %76
   STORE_TAG R1, tnumber
   INTERRUPT 31u
   RETURN R1, 1i
@@ -7446,23 +7470,24 @@ bb_bytecode_1:
    ; exit sync: R4, R3, {}
   CHECK_BUFFER_MUTABLE %15, bb_exit_18
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEI8 %15, 10i, 32i, tbuffer
+  %20 = LOAD_BUFFER_DATA %15
+  BUFFER_WRITEI8 %20, 10i, 32i, tbuffer
   JUMP bb_bytecode_3
 bb_bytecode_3:
   JUMP bb_8
 bb_8:
   CHECK_BUFFER_MUTABLE %15, bb_exit_19
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEI8 %15, 14i, 4i, tbuffer
+  BUFFER_WRITEI8 %20, 14i, 4i, tbuffer
   CHECK_BUFFER_MUTABLE %15, bb_exit_20
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEI8 %15, 13i, 3i, tbuffer
+  BUFFER_WRITEI8 %20, 13i, 3i, tbuffer
   CHECK_BUFFER_MUTABLE %15, bb_exit_21
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEI8 %15, 12i, 2i, tbuffer
+  BUFFER_WRITEI8 %20, 12i, 2i, tbuffer
   CHECK_BUFFER_MUTABLE %15, bb_exit_22
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEI8 %15, 11i, 1i, tbuffer
+  BUFFER_WRITEI8 %20, 11i, 1i, tbuffer
   STORE_DOUBLE R1, 10
   STORE_TAG R1, tnumber
   INTERRUPT 86u
@@ -7516,7 +7541,8 @@ bb_bytecode_1:
    ; exit sync: R4, R3, {}
   CHECK_BUFFER_MUTABLE %15, bb_exit_70
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEI32 %15, 0i, -1i, tbuffer
+  %20 = LOAD_BUFFER_DATA %15
+  BUFFER_WRITEI32 %20, 0i, -1i, tbuffer
   JUMP bb_bytecode_3
 bb_bytecode_3:
   JUMP bb_30
@@ -7527,7 +7553,7 @@ bb_bytecode_5:
 bb_33:
   CHECK_BUFFER_MUTABLE %15, bb_exit_71
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEI32 %15, 0i, -1i, tbuffer
+  BUFFER_WRITEI32 %20, 0i, -1i, tbuffer
   JUMP bb_bytecode_7
 bb_bytecode_7:
   JUMP bb_37
@@ -7538,7 +7564,7 @@ bb_bytecode_9:
 bb_40:
   CHECK_BUFFER_MUTABLE %15, bb_exit_72
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEI16 %15, 0i, 65535i, tbuffer
+  BUFFER_WRITEI16 %20, 0i, 65535i, tbuffer
   JUMP bb_bytecode_11
 bb_bytecode_11:
   JUMP bb_44
@@ -7549,7 +7575,7 @@ bb_bytecode_13:
 bb_47:
   CHECK_BUFFER_MUTABLE %15, bb_exit_73
    ; exit sync: R3, {}
-  BUFFER_WRITEI16 %15, 0i, 65535i, tbuffer
+  BUFFER_WRITEI16 %20, 0i, 65535i, tbuffer
   JUMP bb_bytecode_15
 bb_bytecode_15:
   JUMP bb_51
@@ -7560,7 +7586,7 @@ bb_bytecode_17:
 bb_54:
   CHECK_BUFFER_MUTABLE %15, bb_exit_74
    ; exit sync: R4, R3, {}
-  BUFFER_WRITEI8 %15, 0i, -1i, tbuffer
+  BUFFER_WRITEI8 %20, 0i, -1i, tbuffer
   JUMP bb_bytecode_19
 bb_bytecode_19:
   JUMP bb_58
@@ -7571,7 +7597,7 @@ bb_bytecode_21:
 bb_61:
   CHECK_BUFFER_MUTABLE %15, bb_exit_75
    ; exit sync: R3, {}
-  BUFFER_WRITEI16 %15, 0i, -1i, tbuffer
+  BUFFER_WRITEI16 %20, 0i, -1i, tbuffer
   JUMP bb_bytecode_23
 bb_bytecode_23:
   JUMP bb_65
@@ -7647,108 +7673,109 @@ bb_bytecode_1:
    ; exit sync: R5, {}
   CHECK_BUFFER_MUTABLE %17, bb_exit_56
    ; exit sync: R5, {}
-  %22 = LOAD_DOUBLE R1
-  %23 = NUM_TO_UINT %22
-  BUFFER_WRITEI8 %17, 0i, %23, tbuffer
-  %34 = SEXTI8_INT %23
-  %35 = INT_TO_NUM %34
+  %22 = LOAD_BUFFER_DATA %17
+  %23 = LOAD_DOUBLE R1
+  %24 = NUM_TO_UINT %23
+  BUFFER_WRITEI8 %22, 0i, %24, tbuffer
+  %36 = SEXTI8_INT %24
+  %37 = INT_TO_NUM %36
   CHECK_BUFFER_MUTABLE %17, bb_exit_57
-   ; exit sync: R6, R5, {%35}
-  BUFFER_WRITEF64 %17, 100i, %35, tbuffer
+   ; exit sync: R6, R5, {%37}
+  BUFFER_WRITEF64 %22, 100i, %37, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_58
    ; exit sync: R5, {}
-  BUFFER_WRITEI8 %17, 108i, %23, tbuffer
+  BUFFER_WRITEI8 %22, 108i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_59
    ; exit sync: R5, {}
-  BUFFER_WRITEI8 %17, 109i, %23, tbuffer
+  BUFFER_WRITEI8 %22, 109i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_60
    ; exit sync: R5, {}
-  BUFFER_WRITEI8 %17, 2i, %23, tbuffer
-  %138 = BITAND_UINT %23, 255i
-  %139 = INT_TO_NUM %138
+  BUFFER_WRITEI8 %22, 2i, %24, tbuffer
+  %147 = BITAND_UINT %24, 255i
+  %148 = INT_TO_NUM %147
   CHECK_BUFFER_MUTABLE %17, bb_exit_61
-   ; exit sync: R6, R5, {%139}
-  BUFFER_WRITEF64 %17, 116i, %139, tbuffer
+   ; exit sync: R6, R5, {%148}
+  BUFFER_WRITEF64 %22, 116i, %148, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_62
    ; exit sync: R5, {}
-  BUFFER_WRITEI8 %17, 124i, %23, tbuffer
+  BUFFER_WRITEI8 %22, 124i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_63
    ; exit sync: R5, {}
-  BUFFER_WRITEI8 %17, 125i, %23, tbuffer
+  BUFFER_WRITEI8 %22, 125i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_64
    ; exit sync: R5, {}
-  BUFFER_WRITEI16 %17, 4i, %23, tbuffer
-  %242 = SEXTI16_INT %23
-  %243 = INT_TO_NUM %242
+  BUFFER_WRITEI16 %22, 4i, %24, tbuffer
+  %258 = SEXTI16_INT %24
+  %259 = INT_TO_NUM %258
   CHECK_BUFFER_MUTABLE %17, bb_exit_65
-   ; exit sync: R6, R5, {%243}
-  BUFFER_WRITEF64 %17, 132i, %243, tbuffer
+   ; exit sync: R6, R5, {%259}
+  BUFFER_WRITEF64 %22, 132i, %259, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_66
    ; exit sync: R5, {}
-  BUFFER_WRITEI16 %17, 140i, %23, tbuffer
+  BUFFER_WRITEI16 %22, 140i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_67
    ; exit sync: R5, {}
-  BUFFER_WRITEI16 %17, 142i, %23, tbuffer
+  BUFFER_WRITEI16 %22, 142i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_68
    ; exit sync: R5, {}
-  BUFFER_WRITEI16 %17, 8i, %23, tbuffer
-  %346 = BITAND_UINT %23, 65535i
-  %347 = INT_TO_NUM %346
+  BUFFER_WRITEI16 %22, 8i, %24, tbuffer
+  %369 = BITAND_UINT %24, 65535i
+  %370 = INT_TO_NUM %369
   CHECK_BUFFER_MUTABLE %17, bb_exit_69
-   ; exit sync: R6, R5, {%347}
-  BUFFER_WRITEF64 %17, 148i, %347, tbuffer
+   ; exit sync: R6, R5, {%370}
+  BUFFER_WRITEF64 %22, 148i, %370, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_70
    ; exit sync: R5, {}
-  BUFFER_WRITEI16 %17, 156i, %23, tbuffer
+  BUFFER_WRITEI16 %22, 156i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_71
    ; exit sync: R5, {}
-  BUFFER_WRITEI16 %17, 158i, %23, tbuffer
+  BUFFER_WRITEI16 %22, 158i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_72
    ; exit sync: R5, {}
-  BUFFER_WRITEI32 %17, 12i, %23, tbuffer
-  %450 = TRUNCATE_UINT %23
-  %451 = INT_TO_NUM %450
+  BUFFER_WRITEI32 %22, 12i, %24, tbuffer
+  %480 = TRUNCATE_UINT %24
+  %481 = INT_TO_NUM %480
   CHECK_BUFFER_MUTABLE %17, bb_exit_73
-   ; exit sync: R6, R5, {%451}
-  BUFFER_WRITEF64 %17, 164i, %451, tbuffer
+   ; exit sync: R6, R5, {%481}
+  BUFFER_WRITEF64 %22, 164i, %481, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_74
    ; exit sync: R5, {}
-  BUFFER_WRITEI32 %17, 172i, %23, tbuffer
+  BUFFER_WRITEI32 %22, 172i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_75
    ; exit sync: R5, {}
-  BUFFER_WRITEI32 %17, 176i, %23, tbuffer
+  BUFFER_WRITEI32 %22, 176i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_76
    ; exit sync: R5, {}
-  BUFFER_WRITEI32 %17, 20i, %23, tbuffer
-  %555 = UINT_TO_NUM %23
+  BUFFER_WRITEI32 %22, 20i, %24, tbuffer
+  %592 = UINT_TO_NUM %24
   CHECK_BUFFER_MUTABLE %17, bb_exit_77
-   ; exit sync: R6, R5, {%555}
-  BUFFER_WRITEF64 %17, 180i, %555, tbuffer
+   ; exit sync: R6, R5, {%592}
+  BUFFER_WRITEF64 %22, 180i, %592, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_78
    ; exit sync: R5, {}
-  BUFFER_WRITEI32 %17, 188i, %23, tbuffer
+  BUFFER_WRITEI32 %22, 188i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_79
    ; exit sync: R5, {}
-  BUFFER_WRITEI32 %17, 192i, %23, tbuffer
+  BUFFER_WRITEI32 %22, 192i, %24, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_80
    ; exit sync: R5, {}
-  %646 = LOAD_DOUBLE R2
-  %647 = NUM_TO_FLOAT %646
-  BUFFER_WRITEF32 %17, 28i, %647, tbuffer
-  %659 = FLOAT_TO_NUM %647
+  %689 = LOAD_DOUBLE R2
+  %690 = NUM_TO_FLOAT %689
+  BUFFER_WRITEF32 %22, 28i, %690, tbuffer
+  %703 = FLOAT_TO_NUM %690
   CHECK_BUFFER_MUTABLE %17, bb_exit_81
-   ; exit sync: R6, R5, {%659}
-  BUFFER_WRITEF64 %17, 196i, %659, tbuffer
+   ; exit sync: R6, R5, {%703}
+  BUFFER_WRITEF64 %22, 196i, %703, tbuffer
   CHECK_BUFFER_MUTABLE %17, exit(332)
-  BUFFER_WRITEF32 %17, 196i, %647, tbuffer
+  BUFFER_WRITEF32 %22, 196i, %690, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_82
    ; exit sync: R5, {}
-  BUFFER_WRITEF64 %17, 32i, %646, tbuffer
+  BUFFER_WRITEF64 %22, 32i, %689, tbuffer
   CHECK_BUFFER_MUTABLE %17, bb_exit_83
-   ; exit sync: R6, R5, {%646}
-  BUFFER_WRITEF64 %17, 204i, %646, tbuffer
+   ; exit sync: R6, R5, {%689}
+  BUFFER_WRITEF64 %22, 204i, %689, tbuffer
   CHECK_BUFFER_MUTABLE %17, exit(368)
-  BUFFER_WRITEF32 %17, 204i, %647, tbuffer
+  BUFFER_WRITEF32 %22, 204i, %690, tbuffer
   INTERRUPT 372u
   RETURN R0, 0i
 )"
@@ -7929,26 +7956,27 @@ bb_bytecode_1:
   %26 = TRUNCATE_UINT %12
   CHECK_BUFFER_LEN %24, %26, 0i, 4i, undef, bb_exit_9
    ; exit sync: R5, {%12}
-  %28 = BUFFER_READI32 %24, %26, tbuffer
-  %29 = INT_TO_NUM %28
-  STORE_DOUBLE R3, %29
+  %28 = LOAD_BUFFER_DATA %24
+  %29 = BUFFER_READI32 %28, %26, tbuffer
+  %30 = INT_TO_NUM %29
+  STORE_DOUBLE R3, %30
   STORE_TAG R3, tnumber
-  CHECK_BUFFER_LEN %24, %28, 0i, 4i, undef, exit(15)
-  %42 = BUFFER_READI32 %24, %28, tbuffer
-  %43 = UINT_TO_NUM %42
-  STORE_DOUBLE R4, %43
+  CHECK_BUFFER_LEN %24, %29, 0i, 4i, undef, exit(15)
+  %44 = BUFFER_READI32 %28, %29, tbuffer
+  %45 = UINT_TO_NUM %44
+  STORE_DOUBLE R4, %45
   STORE_TAG R4, tnumber
-  CHECK_BUFFER_LEN %24, %42, 0i, 4i, undef, exit(22)
-  %56 = BUFFER_READI32 %24, %42, tbuffer
-  %57 = INT_TO_NUM %56
-  STORE_SPLIT_TVALUE R5, tnumber, %57
-  %64 = LOAD_POINTER R2
-  %65 = STRING_LEN %64
-  CHECK_BUFFER_LEN %24, %65, 0i, 4i, undef, bb_exit_10
-   ; exit sync: R8, {%65}
-  %79 = BUFFER_READI32 %24, %65, tbuffer
-  %80 = UINT_TO_NUM %79
-  STORE_DOUBLE R6, %80
+  CHECK_BUFFER_LEN %24, %44, 0i, 4i, undef, exit(22)
+  %59 = BUFFER_READI32 %28, %44, tbuffer
+  %60 = INT_TO_NUM %59
+  STORE_SPLIT_TVALUE R5, tnumber, %60
+  %67 = LOAD_POINTER R2
+  %68 = STRING_LEN %67
+  CHECK_BUFFER_LEN %24, %68, 0i, 4i, undef, bb_exit_10
+   ; exit sync: R8, {%68}
+  %83 = BUFFER_READI32 %28, %68, tbuffer
+  %84 = UINT_TO_NUM %83
+  STORE_DOUBLE R6, %84
   STORE_TAG R6, tnumber
   INTERRUPT 38u
   RETURN R3, 4i


### PR DESCRIPTION
With the OptimizeConstProp, this should reduce the number of redundant memory loads for the step of loading ``buffer->data`` which was previously tied to the actual read/write op